### PR TITLE
Add listing of AI models for OpenAI‑compatible providers

### DIFF
--- a/org.sterl.llmpeon.core/src/main/java/org/sterl/llmpeon/ai/AiProvider.java
+++ b/org.sterl.llmpeon.core/src/main/java/org/sterl/llmpeon/ai/AiProvider.java
@@ -82,6 +82,24 @@ public enum AiProvider {
                   .sendThinking(Boolean.FALSE);
             return result.build();
         }
+
+        @Override
+        public List<AiModel> listAiModels(LlmConfig c) {
+            if (c.getUrl() == null || c.getUrl().isBlank()) return fallbackAiModels(c);
+            try {
+                var request = HttpRequest.newBuilder()
+                        .uri(URI.create(c.getUrl() + "/models"))
+                        .header("Authorization", "Bearer " + c.getApiKey())
+                        .GET()
+                        .build();
+                var response = cancelAndSend(request);
+                if (response == null || response.statusCode() > 299) return fallbackAiModels(c);
+                return AiModelParser.parseOpenApiModels(response.body());
+            } catch (Exception e) {
+                log.warn("Failed to load models for {}", this, e);
+                return fallbackAiModels(c);
+            }
+        }
     },
 
     // model URL /api/v1/models

--- a/org.sterl.llmpeon.core/src/main/java/org/sterl/llmpeon/ai/model/AiModelParser.java
+++ b/org.sterl.llmpeon.core/src/main/java/org/sterl/llmpeon/ai/model/AiModelParser.java
@@ -142,6 +142,35 @@ public class AiModelParser {
     }
 
     /**
+     * Parses the OpenAI models API response ({ "data": [...] }).
+     */
+    public static List<AiModel> parseOpenApiModels(String json) {
+        try {
+            var root = MAPPER.readTree(json);
+            var data = root.get("data");
+            var result = new ArrayList<AiModel>();
+            if (data == null || !data.isArray()) return result;
+
+            for (var item : data) {
+                var idNode = item.get("id");
+                if (idNode == null) continue;
+                String id = idNode.asText();
+
+                result.add(AiModel.builder()
+                        .id(id)
+                        .name(id)
+                        .build());
+            }
+
+            Collections.sort(result, (a, b) -> a.getId().compareTo(b.getId()));
+            return result;
+        } catch (Exception e) {
+            e.printStackTrace();
+            return List.of();
+        }
+    }
+
+    /**
      * Parses the LM Studio models API response ({ "models": [...] }).
      * Only returns LLM models that support tool calling.
      */


### PR DESCRIPTION
The REST endpoint currently only returns model IDs, so we display those.