### PR TITLE
Enable sendThinking option in AiProvider configuration

### DIFF
--- a/org.sterl.llmpeon.core/src/main/java/org/sterl/llmpeon/ai/AiProvider.java
+++ b/org.sterl.llmpeon.core/src/main/java/org/sterl/llmpeon/ai/AiProvider.java
@@ -76,6 +76,7 @@ public enum AiProvider {
                     .modelName(c.getModel())
                     .apiKey(c.getApiKey())
                     .returnThinking(Boolean.TRUE)
+                    .sendThinking(Boolean.TRUE)
                     .build();
         }
 

--- a/org.sterl.llmpeon.core/src/main/java/org/sterl/llmpeon/ai/LlmConfig.java
+++ b/org.sterl.llmpeon.core/src/main/java/org/sterl/llmpeon/ai/LlmConfig.java
@@ -45,6 +45,7 @@ public class LlmConfig {
     private final String skillDirectory = null;
     @Default
     private final boolean diskToolsEnabled = false;
+    private final boolean shellCommandConfirmationRequired = false;
 
     public static LlmConfig newConfig(String model, String url) {
         return LlmConfig.builder().model(model).url(url).build();

--- a/org.sterl.llmpeon.core/src/main/java/org/sterl/llmpeon/tool/tools/ShellTool.java
+++ b/org.sterl.llmpeon.core/src/main/java/org/sterl/llmpeon/tool/tools/ShellTool.java
@@ -20,13 +20,24 @@ import dev.langchain4j.agent.tool.Tool;
  */
 public class ShellTool extends AbstractTool {
 
+	@FunctionalInterface
+    public interface ShellConfirmationProvider {
+        String confirm(String command, String workingDirectory);
+    }
+
     private static final long DEFAULT_TIMEOUT_MS = 120_000;
     private static final long MAX_TIMEOUT_MS = 600_000;
     private static final int MAX_OUTPUT_LENGTH = 30_000;
     private static final int DEFAULT_TAIL_LINES = 50;
-    
+
+    private ShellConfirmationProvider confirmationProvider = null;
+
     @Override
     public boolean isEditTool() { return true; }
+
+    public void setConfirmationProvider(ShellConfirmationProvider confirmationProvider) {
+        this.confirmationProvider = confirmationProvider;
+    }
 
     @Tool("OS/user info (os.name, user.name, etc.).")
     public String readOperationSystemInformation() {
@@ -49,6 +60,17 @@ public class ShellTool extends AbstractTool {
 
         ArgsUtil.requireNonBlank(command, "command");
         ArgsUtil.requireNonBlank(workingDirectory, "workingDirectory");
+
+        if (confirmationProvider != null) {
+            String updatedCommand = confirmationProvider.confirm(command, workingDirectory);
+
+            if ("No".equalsIgnoreCase(updatedCommand)) {
+                return "Shell command execution denied!";
+            }
+            if (!"Yes".equalsIgnoreCase(updatedCommand)) {
+                command = updatedCommand;
+            }
+        }
 
         Path effectiveDir = Path.of(workingDirectory).toAbsolutePath().normalize();
         if (!effectiveDir.toFile().isDirectory()) {

--- a/org.sterl.llmpeon/src/org/sterl/llmpeon/parts/AIChatView.java
+++ b/org.sterl.llmpeon/src/org/sterl/llmpeon/parts/AIChatView.java
@@ -57,6 +57,7 @@ import org.sterl.llmpeon.parts.widget.UserInputWidget;
 import org.sterl.llmpeon.parts.widget.UserQuestionWidget;
 import org.sterl.llmpeon.shared.StringUtil;
 import org.sterl.llmpeon.tool.ToolService;
+import org.sterl.llmpeon.tool.tools.ShellTool;
 import org.sterl.llmpeon.tool.model.SimpleMessage;
 import org.sterl.llmpeon.tool.model.SimpleMessage.Type;
 import org.sterl.llmpeon.voice.VoiceConfig;
@@ -374,6 +375,30 @@ public class AIChatView implements EclipseAiMonitor {
         
         var prefs = InstanceScope.INSTANCE.getNode(PeonConstants.PLUGIN_ID);
         debugLog.set(prefs.getBoolean(PeonConstants.PREF_LOG_RESPONSE, false));
+
+        if (prefs.getBoolean(PeonConstants.PREF_SHELL_CONFIRMATION_ENABLED, false)) {
+            aiService.getToolService().getTool(ShellTool.class).ifPresent(shellTool -> {
+                shellTool.setConfirmationProvider((command, workingDirectory) -> {
+                    var latch = new java.util.concurrent.CountDownLatch(1);
+                    var answer = new java.util.concurrent.atomic.AtomicReference<>("No");
+                    showQuestion("Allow executing shell command in the \"" + workingDirectory + "\" directory? " +
+                            "(or you can enter a new command to execute below)\n\n" + command,
+                            java.util.List.of("Yes", "No"),
+                            a -> { answer.set(a); latch.countDown(); });
+                    try {
+                        latch.await();
+                    } catch (InterruptedException e) {
+                        Thread.currentThread().interrupt();
+                    }
+                    return answer.get();
+                });
+            });
+
+        } else {
+            aiService.getToolService().getTool(ShellTool.class).ifPresent(shellTool -> {
+                shellTool.setConfirmationProvider(null);
+            });
+        }
     }
 
     private void applyMcpConfig() {

--- a/org.sterl.llmpeon/src/org/sterl/llmpeon/parts/PeonConstants.java
+++ b/org.sterl.llmpeon/src/org/sterl/llmpeon/parts/PeonConstants.java
@@ -13,6 +13,7 @@ public interface PeonConstants {
     String PREF_API_KEY          = "llm.apiKey";
     String PREF_SKILL_DIRECTORY  = "llm.skillDirectory";
     String PREF_DISK_TOOLS_ENABLED = "llm.diskToolsEnabled";
+    String PREF_SHELL_CONFIRMATION_ENABLED = "llm.shellConfirmationEnabled";
     
     String PREF_LOG_RESPONSE    = "llm.logResponse";
 

--- a/org.sterl.llmpeon/src/org/sterl/llmpeon/parts/config/AiConfigPreferenceView.java
+++ b/org.sterl.llmpeon/src/org/sterl/llmpeon/parts/config/AiConfigPreferenceView.java
@@ -56,6 +56,7 @@ public class AiConfigPreferenceView extends FieldEditorPreferencePage implements
         addField(new IntegerFieldEditor(PeonConstants.PREF_TOKEN_WINDOW, "Token Window:", getFieldEditorParent()));
         addField(new BooleanFieldEditor(PeonConstants.PREF_THINKING_ENABLED, "Supports Thinking", getFieldEditorParent()));
         addField(new BooleanFieldEditor(PeonConstants.PREF_DISK_TOOLS_ENABLED, "Enable Disk File Tools (outside Eclipse workspace)", getFieldEditorParent()));
+        addField(new BooleanFieldEditor(PeonConstants.PREF_SHELL_CONFIRMATION_ENABLED, "Require confirmation for shell commands before run", getFieldEditorParent()));
         apiKeyEditor = new StringFieldEditor(PeonConstants.PREF_API_KEY, "API Key:", getFieldEditorParent());
         addField(apiKeyEditor);
         addField(new StringFieldEditor(PeonConstants.PREF_SKILL_DIRECTORY, "Skills directory:", getFieldEditorParent()));

--- a/org.sterl.llmpeon/src/org/sterl/llmpeon/parts/config/LlmPreferenceInitializer.java
+++ b/org.sterl.llmpeon/src/org/sterl/llmpeon/parts/config/LlmPreferenceInitializer.java
@@ -29,6 +29,7 @@ public class LlmPreferenceInitializer extends AbstractPreferenceInitializer {
         defaults.put(PeonConstants.PREF_API_KEY, "");
         defaults.put(PeonConstants.PREF_SKILL_DIRECTORY, "");
         defaults.putBoolean(PeonConstants.PREF_DISK_TOOLS_ENABLED, false);
+        defaults.putBoolean(PeonConstants.PREF_SHELL_CONFIRMATION_ENABLED, false);
     }
     
     public static LlmConfig buildWithDefaults() {


### PR DESCRIPTION
Hi Sterl,

First of all thanks for this plugin, love it so far very much!

Tried to use DeepSeek with it and noticed this error:
The `reasoning_content` in the thinking mode must be passed back to the API.

so added the sendThinking just like you have for Gemini and that seems to have fixed it, tried some openai models too with this config change and seems to be still working fine so not sure if this is the right fix for the DeepSeek compatibility or not but wanted to let you know in any case.

Regards,
Julius