### PR TITLE
Harden getRawLocation null cases beyond StandingOrdersBuilder

### DIFF
--- a/org.sterl.llmpeon/src/org/sterl/llmpeon/parts/config/LlmPreferenceInitializer.java
+++ b/org.sterl.llmpeon/src/org/sterl/llmpeon/parts/config/LlmPreferenceInitializer.java
@@ -13,6 +13,7 @@ import org.sterl.llmpeon.ai.AiProvider;
 import org.sterl.llmpeon.ai.LlmConfig;
 import org.sterl.llmpeon.parts.PeonConstants;
 import org.sterl.llmpeon.parts.shared.EclipseUtil;
+import org.sterl.llmpeon.parts.shared.JdtUtil;
 import org.sterl.llmpeon.shared.StringUtil;
 
 public class LlmPreferenceInitializer extends AbstractPreferenceInitializer {
@@ -43,11 +44,17 @@ public class LlmPreferenceInitializer extends AbstractPreferenceInitializer {
         if (StringUtil.hasValue(skillDir) && !Files.isDirectory(Path.of(skillDir))) {
             var dir = EclipseUtil.resolveInEclipse(skillDir);
             if (dir.isPresent()) {
+                var resource = dir.get();
                 // save Eclipse workspace-relative path to prefs (portable)
-                prefs.put(PeonConstants.PREF_SKILL_DIRECTORY, dir.get().getFullPath().toOSString());
-                // use absolute file system path for SkillService
-                LOG.info("Resolved skill dir " + skillDir + " as " + dir.get().getRawLocation().toOSString());
-                skillDir = dir.get().getRawLocation().toOSString();
+                prefs.put(PeonConstants.PREF_SKILL_DIRECTORY, resource.getFullPath().toOSString());
+                var abs = JdtUtil.diskPathOf(resource);
+                if (abs != null) {
+                    LOG.info("Resolved skill dir " + skillDir + " as " + abs);
+                    skillDir = abs;
+                } else {
+                    LOG.warn("Could not resolve skill dir to a filesystem path for " + resource.getFullPath());
+                    skillDir = "";
+                }
             }
         }
 

--- a/org.sterl.llmpeon/src/org/sterl/llmpeon/parts/shared/EclipseUtil.java
+++ b/org.sterl.llmpeon/src/org/sterl/llmpeon/parts/shared/EclipseUtil.java
@@ -29,7 +29,15 @@ public class EclipseUtil {
     }
     
     public static Path workspacePath() {
-        return ResourcesPlugin.getWorkspace().getRoot().getRawLocation().toFile().toPath();
+        var root = ResourcesPlugin.getWorkspace().getRoot();
+        IPath loc = root.getRawLocation();
+        if (loc == null) {
+            loc = root.getLocation();
+        }
+        if (loc == null) {
+            throw new IllegalStateException("Workspace root has no filesystem location");
+        }
+        return loc.toFile().toPath();
     }
 
     /**

--- a/org.sterl.llmpeon/src/org/sterl/llmpeon/parts/shared/JdtUtil.java
+++ b/org.sterl.llmpeon/src/org/sterl/llmpeon/parts/shared/JdtUtil.java
@@ -110,16 +110,17 @@ public class JdtUtil {
     }
     
     /**
-     * Workspace-relative path for a type.
+     * Best-effort absolute filesystem path for a workspace resource (project, folder, file).
+     * {@link IResource#getRawLocation()} may be {@code null} for some project layouts; falls back to
+     * {@link IResource#getLocation()}.
      */
     @Nullable
-    public static String diskPathOf(IProject value) {
+    public static String diskPathOf(@Nullable IResource value) {
         if (value == null) return null;
-        var projectPath = value.getRawLocation();
-        if (projectPath == null) projectPath = value.getLocation();
-        
-        if (projectPath == null) return null;
-        return projectPath.toOSString();
+        var path = value.getRawLocation();
+        if (path == null) path = value.getLocation();
+        if (path == null) return null;
+        return path.toOSString();
     }
 
     /**


### PR DESCRIPTION
Use JdtUtil.diskPathOf(IResource) for any workspace resource, fix skill
dir resolution in LlmPreferenceInitializer, and fall back in
EclipseUtil.workspacePath(). Fixes #38

