### PR TITLE
Feature/35 skill slash commands

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,4 @@
 {
-    "java.configuration.updateBuildConfiguration": "interactive"
+    "java.configuration.updateBuildConfiguration": "interactive",
+    "java.compile.nullAnalysis.mode": "automatic"
 }

--- a/org.sterl.llmpeon.core/pom.xml
+++ b/org.sterl.llmpeon.core/pom.xml
@@ -12,6 +12,10 @@
 
     <artifactId>llmpeon-core</artifactId>
 
+    <properties>
+        <lombok.version>1.18.44</lombok.version>
+    </properties>
+
     <dependencyManagement>
         <dependencies>
             <dependency>
@@ -29,7 +33,7 @@
         <dependency>
             <groupId>org.projectlombok</groupId>
             <artifactId>lombok</artifactId>
-            <version>1.18.44</version>
+            <version>${lombok.version}</version>
             <optional>true</optional>
         </dependency>
         
@@ -129,6 +133,13 @@
                 <version>3.15.0</version>
                 <configuration>
                     <release>${java.version}</release>
+                    <annotationProcessorPaths>
+                        <path>
+                            <groupId>org.projectlombok</groupId>
+                            <artifactId>lombok</artifactId>
+                            <version>${lombok.version}</version>
+                        </path>
+                    </annotationProcessorPaths>
                 </configuration>
             </plugin>
             <plugin>

--- a/org.sterl.llmpeon.core/src/main/java/org/sterl/llmpeon/AbstractChatService.java
+++ b/org.sterl.llmpeon.core/src/main/java/org/sterl/llmpeon/AbstractChatService.java
@@ -55,6 +55,13 @@ public abstract class AbstractChatService {
     private List<ChatMessage> standingOrders = Collections.emptyList();
     private int tokenSize = 0;
 
+    /**
+     * One-shot system prompt set by a slash command invocation. When non-null the next call to
+     * {@link #buildStaticMessages()} uses this value as the system prompt instead of
+     * {@link #getSystemPrompt()} and clears the field. Subsequent calls revert to the base prompt.
+     */
+    private String oneShotSystemPrompt;
+
     protected AbstractChatService(ConfiguredModel configuredModel, ToolService toolService,
             SkillService skillService, TemplateContext templateContext) {
         this.toolService = toolService;
@@ -154,12 +161,33 @@ public abstract class AbstractChatService {
 
     private List<ChatMessage> buildStaticMessages() {
         var messages = new ArrayList<ChatMessage>();
-        messages.add(SystemMessage.from(getSystemPrompt()));
+        var override = consumeOneShotSystemPrompt();
+        messages.add(SystemMessage.from(override != null ? override : getSystemPrompt()));
 
         messages.addAll(standingOrders);
+        // Skills are still advertised even when a slash command overrode the base prompt; the
+        // command body and the skill catalog are orthogonal.
         var skillMsg = skillService.skillMessage(templateContext);
         if (skillMsg != null) messages.add(skillMsg);
         return messages;
+    }
+
+    /**
+     * Sets a one-shot system prompt that replaces {@link #getSystemPrompt()} for the very next
+     * {@link #call(String, AiMonitor)} only. Pass {@code null} to clear without consuming.
+     */
+    public void setOneShotSystemPrompt(String systemPrompt) {
+        this.oneShotSystemPrompt = (systemPrompt == null || systemPrompt.isBlank()) ? null : systemPrompt;
+    }
+
+    public boolean hasOneShotSystemPrompt() {
+        return oneShotSystemPrompt != null;
+    }
+
+    private String consumeOneShotSystemPrompt() {
+        var value = oneShotSystemPrompt;
+        oneShotSystemPrompt = null;
+        return value;
     }
 
     private void updateTokenCount(ChatResponse response) {

--- a/org.sterl.llmpeon.core/src/main/java/org/sterl/llmpeon/ai/LlmConfig.java
+++ b/org.sterl.llmpeon.core/src/main/java/org/sterl/llmpeon/ai/LlmConfig.java
@@ -44,6 +44,8 @@ public class LlmConfig {
     @Default
     private final String skillDirectory = null;
     @Default
+    private final String commandDirectory = null;
+    @Default
     private final boolean diskToolsEnabled = false;
     private final boolean shellCommandConfirmationRequired = false;
     

--- a/org.sterl.llmpeon.core/src/main/java/org/sterl/llmpeon/command/CommandRecord.java
+++ b/org.sterl.llmpeon.core/src/main/java/org/sterl/llmpeon/command/CommandRecord.java
@@ -1,0 +1,60 @@
+package org.sterl.llmpeon.command;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+/**
+ * A single user-defined slash command.
+ *
+ * <p>Loaded from a {@code <name>.md} file inside the configured commands directory.
+ * The filename (without the {@code .md} extension) becomes the {@link #name()}.
+ * Optional YAML frontmatter with a {@code description:} field is supported and
+ * surfaced to the user in the slash menu; if absent, {@link #description()} is {@code null}.</p>
+ */
+public record CommandRecord(String name, String description, Path commandFile) {
+
+    public String readFullContent() {
+        try {
+            return Files.readString(commandFile);
+        } catch (Exception e) {
+            throw new RuntimeException("Failed to read " + commandFile, e);
+        }
+    }
+
+    /**
+     * Returns the markdown body (the content after the optional YAML frontmatter).
+     * If the file has no frontmatter, the full content is returned unchanged.
+     */
+    public String readBody() {
+        var raw = readFullContent();
+        return stripFrontmatter(raw);
+    }
+
+    static String stripFrontmatter(String raw) {
+        if (raw == null) return "";
+        // Trim leading whitespace/newlines before frontmatter detection.
+        int start = 0;
+        while (start < raw.length() && (raw.charAt(start) == '\n' || raw.charAt(start) == '\r')) start++;
+        if (start >= raw.length() || !raw.startsWith("---", start)) return raw;
+        // Locate the closing '---' on its own line.
+        int idx = start + 3;
+        // Skip the newline after the opening fence.
+        while (idx < raw.length() && raw.charAt(idx) != '\n') idx++;
+        if (idx >= raw.length()) return raw;
+        idx++;
+        while (idx < raw.length()) {
+            int lineEnd = raw.indexOf('\n', idx);
+            String line = lineEnd < 0 ? raw.substring(idx) : raw.substring(idx, lineEnd);
+            if (line.strip().equals("---")) {
+                return lineEnd < 0 ? "" : raw.substring(lineEnd + 1);
+            }
+            if (lineEnd < 0) break;
+            idx = lineEnd + 1;
+        }
+        return raw;
+    }
+
+    public String shortDescription() {
+        return "Command[name=" + name + (description == null ? "" : ", description=" + description) + "]";
+    }
+}

--- a/org.sterl.llmpeon.core/src/main/java/org/sterl/llmpeon/command/CommandService.java
+++ b/org.sterl.llmpeon.core/src/main/java/org/sterl/llmpeon/command/CommandService.java
@@ -1,0 +1,139 @@
+package org.sterl.llmpeon.command;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.nio.file.DirectoryStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Locale;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+/**
+ * Loads user-defined slash commands from a configured directory.
+ *
+ * <p>Each {@code <name>.md} file directly inside the directory becomes one
+ * {@link CommandRecord}. Unlike {@link org.sterl.llmpeon.skill.SkillService}, the
+ * frontmatter is optional and only the {@code description} field is parsed.
+ * Hidden files and files in subdirectories are ignored.</p>
+ */
+public class CommandService {
+
+    private Path commandsDirectory;
+    private final List<CommandRecord> commands = new ArrayList<>();
+
+    public CommandService() {
+    }
+
+    public CommandService(Path commandsDirectory) throws IOException {
+        refresh(commandsDirectory);
+    }
+
+    public List<CommandRecord> getCommands() {
+        return List.copyOf(commands);
+    }
+
+    public int loadedCommandCount() {
+        return commands.size();
+    }
+
+    public boolean refresh(String newPath) throws IOException {
+        return refresh(newPath == null || newPath.isBlank() ? null : Path.of(newPath));
+    }
+
+    public boolean refresh(Path newPath) throws IOException {
+        if (newPath == null && commandsDirectory == null) return false;
+        if (newPath != null && Objects.equals(newPath, commandsDirectory)) {
+            // path unchanged — still re-scan in case files were added/removed externally
+            return reload();
+        }
+        this.commands.clear();
+        if (newPath == null) {
+            this.commandsDirectory = null;
+            return true;
+        }
+        this.commandsDirectory = newPath.toAbsolutePath().normalize();
+        reload();
+        return true;
+    }
+
+    private boolean reload() throws IOException {
+        this.commands.clear();
+        if (commandsDirectory == null || !Files.isDirectory(commandsDirectory)) return true;
+
+        try (DirectoryStream<Path> stream = Files.newDirectoryStream(commandsDirectory, "*.md")) {
+            for (Path file : stream) {
+                if (!Files.isRegularFile(file)) continue;
+                var fileName = file.getFileName().toString();
+                if (fileName.startsWith(".")) continue; // skip hidden files
+                CommandRecord cmd = parseCommandFile(file);
+                if (cmd != null) commands.add(cmd);
+            }
+        }
+        commands.sort(Comparator.comparing(c -> c.name().toLowerCase(Locale.ROOT)));
+        return true;
+    }
+
+    static CommandRecord parseCommandFile(Path file) throws IOException {
+        if (!Files.isRegularFile(file)) return null;
+        var fileName = file.getFileName().toString();
+        if (!fileName.endsWith(".md")) return null;
+        var name = fileName.substring(0, fileName.length() - 3);
+        if (name.isBlank()) return null;
+
+        String description = readOptionalDescription(file);
+        return new CommandRecord(name, description, file);
+    }
+
+    private static String readOptionalDescription(Path file) throws IOException {
+        try (BufferedReader reader = Files.newBufferedReader(file)) {
+            String first = reader.readLine();
+            while (first != null && first.isBlank()) first = reader.readLine();
+            if (first == null || !"---".equals(first.trim())) return null;
+
+            String line;
+            while ((line = reader.readLine()) != null) {
+                String trimmed = line.trim();
+                if ("---".equals(trimmed)) return null;
+                if (trimmed.startsWith("description:")) {
+                    return stripYamlValue(trimmed.substring("description:".length()));
+                }
+            }
+        }
+        return null;
+    }
+
+    private static String stripYamlValue(String value) {
+        if (value == null) return null;
+        value = value.strip();
+        if (value.length() >= 2
+                && ((value.startsWith("\"") && value.endsWith("\""))
+                 || (value.startsWith("'") && value.endsWith("'")))) {
+            value = value.substring(1, value.length() - 1);
+        }
+        return value.isEmpty() ? null : value;
+    }
+
+    public Optional<CommandRecord> get(String name) {
+        if (name == null || name.isBlank()) return Optional.empty();
+        return commands.stream()
+                .filter(c -> c.name().equalsIgnoreCase(name))
+                .findFirst();
+    }
+
+    public boolean hasCommands() {
+        return !commands.isEmpty();
+    }
+
+    public String commandNames() {
+        return commands.stream().map(CommandRecord::name).collect(Collectors.joining(", "));
+    }
+
+    public Path getCommandsDirectory() {
+        return commandsDirectory;
+    }
+}

--- a/org.sterl.llmpeon.core/src/test/java/org/sterl/llmpeon/command/CommandServiceTest.java
+++ b/org.sterl.llmpeon.core/src/test/java/org/sterl/llmpeon/command/CommandServiceTest.java
@@ -1,0 +1,149 @@
+package org.sterl.llmpeon.command;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+class CommandServiceTest {
+
+    @Test
+    void emptyDirectoryReturnsZeroCommands(@TempDir Path tmp) throws Exception {
+        var service = new CommandService();
+        service.refresh(tmp);
+        assertThat(service.getCommands()).isEmpty();
+        assertThat(service.loadedCommandCount()).isZero();
+    }
+
+    @Test
+    void nonExistingDirectoryReturnsZeroCommands(@TempDir Path tmp) throws Exception {
+        var service = new CommandService();
+        service.refresh(tmp.resolve("does-not-exist"));
+        assertThat(service.getCommands()).isEmpty();
+    }
+
+    @Test
+    void readsPlainMarkdownWithoutFrontmatter(@TempDir Path tmp) throws Exception {
+        Files.writeString(tmp.resolve("review.md"),
+                "Review the code carefully and report findings.");
+        var service = new CommandService();
+        service.refresh(tmp);
+
+        assertThat(service.getCommands()).hasSize(1);
+        var cmd = service.getCommands().get(0);
+        assertThat(cmd.name()).isEqualTo("review");
+        assertThat(cmd.description()).isNull();
+        assertThat(cmd.readFullContent()).contains("Review the code");
+        assertThat(cmd.readBody()).isEqualTo(cmd.readFullContent());
+    }
+
+    @Test
+    void parsesOptionalDescriptionFromFrontmatter(@TempDir Path tmp) throws Exception {
+        Files.writeString(tmp.resolve("plan.md"), """
+                ---
+                description: Build a high-level implementation plan
+                ---
+
+                # Plan
+
+                Body content here.
+                """);
+        var service = new CommandService();
+        service.refresh(tmp);
+
+        var cmd = service.get("plan").orElseThrow();
+        assertThat(cmd.name()).isEqualTo("plan");
+        assertThat(cmd.description()).isEqualTo("Build a high-level implementation plan");
+        assertThat(cmd.readBody().strip()).startsWith("# Plan");
+    }
+
+    @Test
+    void readBodyStripsFrontmatterWhenPresent(@TempDir Path tmp) throws Exception {
+        Files.writeString(tmp.resolve("doc.md"), """
+                ---
+                description: docs
+                ---
+                Hello body
+                """);
+        var service = new CommandService();
+        service.refresh(tmp);
+
+        var cmd = service.get("doc").orElseThrow();
+        assertThat(cmd.readBody().strip()).isEqualTo("Hello body");
+    }
+
+    @Test
+    void caseInsensitiveLookup(@TempDir Path tmp) throws Exception {
+        Files.writeString(tmp.resolve("Review.md"), "x");
+        var service = new CommandService();
+        service.refresh(tmp);
+
+        assertThat(service.get("review")).isPresent();
+        assertThat(service.get("REVIEW")).isPresent();
+    }
+
+    @Test
+    void ignoresHiddenAndNonMarkdownFiles(@TempDir Path tmp) throws Exception {
+        Files.writeString(tmp.resolve(".secret.md"), "x");
+        Files.writeString(tmp.resolve("notes.txt"), "x");
+        Files.writeString(tmp.resolve("ok.md"), "y");
+        var service = new CommandService();
+        service.refresh(tmp);
+
+        assertThat(service.getCommands()).hasSize(1);
+        assertThat(service.get("ok")).isPresent();
+    }
+
+    @Test
+    void ignoresFilesInSubdirectories(@TempDir Path tmp) throws Exception {
+        var sub = Files.createDirectory(tmp.resolve("sub"));
+        Files.writeString(sub.resolve("nested.md"), "x");
+        Files.writeString(tmp.resolve("flat.md"), "y");
+
+        var service = new CommandService();
+        service.refresh(tmp);
+        assertThat(service.getCommands()).hasSize(1);
+        assertThat(service.get("flat")).isPresent();
+        assertThat(service.get("nested")).isEmpty();
+    }
+
+    @Test
+    void refreshWithSameDirectoryReloadsContent(@TempDir Path tmp) throws Exception {
+        Files.writeString(tmp.resolve("a.md"), "x");
+        var service = new CommandService();
+        service.refresh(tmp);
+        assertThat(service.loadedCommandCount()).isEqualTo(1);
+
+        Files.writeString(tmp.resolve("b.md"), "y");
+        service.refresh(tmp);
+        assertThat(service.loadedCommandCount()).isEqualTo(2);
+    }
+
+    @Test
+    void commandNamesAreSortedCaseInsensitive(@TempDir Path tmp) throws Exception {
+        Files.writeString(tmp.resolve("zebra.md"), "x");
+        Files.writeString(tmp.resolve("Alpha.md"), "x");
+        Files.writeString(tmp.resolve("beta.md"), "x");
+
+        var service = new CommandService();
+        service.refresh(tmp);
+
+        assertThat(service.getCommands())
+                .extracting(CommandRecord::name)
+                .containsExactly("Alpha", "beta", "zebra");
+    }
+
+    @Test
+    void clearingDirectoryRemovesAllCommands(@TempDir Path tmp) throws Exception {
+        Files.writeString(tmp.resolve("a.md"), "x");
+        var service = new CommandService();
+        service.refresh(tmp);
+        assertThat(service.loadedCommandCount()).isEqualTo(1);
+
+        service.refresh((String) null);
+        assertThat(service.loadedCommandCount()).isZero();
+    }
+}

--- a/org.sterl.llmpeon/src/org/sterl/llmpeon/parts/AIChatView.java
+++ b/org.sterl.llmpeon/src/org/sterl/llmpeon/parts/AIChatView.java
@@ -165,6 +165,8 @@ public class AIChatView implements EclipseAiMonitor {
         aiService.getToolService().addTool(new AskUserTool(
             (question, answers, onAnswer) -> showQuestion(question, answers, onAnswer)
         ));
+
+        chatInput.enableSlashCommands(() -> aiService.getCommandService().getCommands());
     }
 
     private void onClear() {
@@ -349,6 +351,11 @@ public class AIChatView implements EclipseAiMonitor {
             aiService.getSkillService().refresh(config.getSkillDirectory());
         } catch (IOException e) {
             throw new RuntimeException("Failed to load " + config.getSkillDirectory());
+        }
+        try {
+            aiService.getCommandService().refresh(config.getCommandDirectory());
+        } catch (IOException e) {
+            throw new RuntimeException("Failed to load " + config.getCommandDirectory());
         }
         aiService.updateConfig(config);
         // Sync the Think toggle to the config default. The user can override this per-session
@@ -540,6 +547,8 @@ public class AIChatView implements EclipseAiMonitor {
         }
 
         final var active = getActiveService();
+        if (!applySlashCommandIfPresent(active)) return;
+
         final var selection = getUserSelection();
         final var needsSelection = !active.hasUserText(selection);
 
@@ -653,6 +662,45 @@ public class AIChatView implements EclipseAiMonitor {
 
     private void onSkillsToggle(boolean enabled) {
         aiService.getSkillService().setEnabled(enabled);
+    }
+
+    /**
+     * If the chat input starts with {@code /name}, looks up the command and installs its body as
+     * the one-shot system prompt on the active chat service. The slash token is stripped from the
+     * input so only the trailing user text is sent. Returns {@code false} and reports a problem
+     * when the name is unknown so the caller can abort the send.
+     */
+    private boolean applySlashCommandIfPresent(AbstractChatService active) {
+        var raw = chatInput.getText();
+        if (raw == null) return true;
+        var trimmed = raw.stripLeading();
+        if (!trimmed.startsWith("/")) return true;
+
+        int wsIdx = -1;
+        for (int i = 1; i < trimmed.length(); i++) {
+            if (Character.isWhitespace(trimmed.charAt(i))) { wsIdx = i; break; }
+        }
+        var name = wsIdx < 0 ? trimmed.substring(1) : trimmed.substring(1, wsIdx);
+        var rest = wsIdx < 0 ? "" : trimmed.substring(wsIdx).stripLeading();
+        if (name.isBlank()) return true;
+
+        var commandService = aiService.getCommandService();
+        var command = commandService.get(name);
+        if (command.isEmpty()) {
+            var available = commandService.commandNames();
+            var hint = available.isEmpty() ? "(no commands loaded)" : "Available: " + available;
+            chatHistory.appendMessage(new SimpleMessage(Type.PROBLEM,
+                    "Unknown command /" + name + ". " + hint));
+            return false;
+        }
+
+        var prompt = aiService.getTemplateContext().process(command.get().readBody());
+        active.setOneShotSystemPrompt(prompt);
+        // If only the slash token was entered, keep it visible as the user turn so the chat
+        // history clearly shows which command was invoked AND the LLM receives a non-empty turn.
+        chatInput.setText(rest.isEmpty() ? "/" + name : rest);
+        chatInput.dismissSlashMenu();
+        return true;
     }
 
     private void onMicClick() {

--- a/org.sterl.llmpeon/src/org/sterl/llmpeon/parts/PeonAiService.java
+++ b/org.sterl.llmpeon/src/org/sterl/llmpeon/parts/PeonAiService.java
@@ -12,6 +12,7 @@ import org.sterl.llmpeon.AiPlannerService;
 import org.sterl.llmpeon.ai.ConfiguredModel;
 import org.sterl.llmpeon.ai.LlmConfig;
 import org.sterl.llmpeon.ai.model.AiModel;
+import org.sterl.llmpeon.command.CommandService;
 import org.sterl.llmpeon.parts.agent.AgentModeService;
 import org.sterl.llmpeon.parts.agentsmd.AgentsMdService;
 import org.sterl.llmpeon.parts.config.LlmPreferenceInitializer;
@@ -51,6 +52,7 @@ public class PeonAiService {
     private final ConfiguredModel configuredModel;
     private final ToolService toolService;
     private final SkillService skillService;
+    private final CommandService commandService;
     private final TemplateContext context;
     private final AgentsMdService agentsMdService;
     private final AiDeveloperService developerService;
@@ -77,6 +79,7 @@ public class PeonAiService {
         this.developerService = developerService;
         this.toolService = null;
         this.skillService = null;
+        this.commandService = null;
         this.context = null;
         this.agentsMdService = null;
         this.agentMode = null;
@@ -103,6 +106,7 @@ public class PeonAiService {
         var rootPath            = EclipseUtil.workspacePath();
         toolService             = new ToolService();
         skillService            = new SkillService();
+        commandService          = new CommandService();
         context                 = new TemplateContext(rootPath);
         agentsMdService         = new AgentsMdService();
 
@@ -181,6 +185,11 @@ public class PeonAiService {
                 throw new RuntimeException("Failed to load skills from " + config.getSkillDirectory(), e);
             }
         }
+        try {
+            commandService.refresh(config.getCommandDirectory());
+        } catch (IOException e) {
+            throw new RuntimeException("Failed to load commands from " + config.getCommandDirectory(), e);
+        }
     }
 
     // -------------------------------------------------------------------------
@@ -250,6 +259,10 @@ public class PeonAiService {
 
     public SkillService getSkillService() {
         return skillService;
+    }
+
+    public CommandService getCommandService() {
+        return commandService;
     }
 
     public TemplateContext getTemplateContext() {

--- a/org.sterl.llmpeon/src/org/sterl/llmpeon/parts/PeonConstants.java
+++ b/org.sterl.llmpeon/src/org/sterl/llmpeon/parts/PeonConstants.java
@@ -15,6 +15,7 @@ public interface PeonConstants {
 
     String PREF_API_KEY                    = "llm.apiKey";
     String PREF_SKILL_DIRECTORY            = "llm.skillDirectory";
+    String PREF_COMMAND_DIRECTORY          = "llm.commandDirectory";
     String PREF_DISK_TOOLS_ENABLED         = "llm.diskToolsEnabled";
     String PREF_SHELL_CONFIRMATION_ENABLED = "llm.shellConfirmationEnabled";
     

--- a/org.sterl.llmpeon/src/org/sterl/llmpeon/parts/config/AiConfigPreferenceView.java
+++ b/org.sterl.llmpeon/src/org/sterl/llmpeon/parts/config/AiConfigPreferenceView.java
@@ -69,7 +69,8 @@ public class AiConfigPreferenceView extends FieldEditorPreferencePage implements
         apiKeyEditor = new StringFieldEditor(PeonConstants.PREF_API_KEY, "API Key:", getFieldEditorParent());
         addField(apiKeyEditor);
         addField(new StringFieldEditor(PeonConstants.PREF_SKILL_DIRECTORY, "Skills directory:", getFieldEditorParent()));
-        
+        addField(new StringFieldEditor(PeonConstants.PREF_COMMAND_DIRECTORY, "Commands directory:", getFieldEditorParent()));
+
         buildGithubLogin();
         // -- Debug stuff
         addField(new BooleanFieldEditor(PeonConstants.PREF_LOG_RESPONSE, "Log response for debugging", getFieldEditorParent()));

--- a/org.sterl.llmpeon/src/org/sterl/llmpeon/parts/config/LlmPreferenceInitializer.java
+++ b/org.sterl.llmpeon/src/org/sterl/llmpeon/parts/config/LlmPreferenceInitializer.java
@@ -33,6 +33,7 @@ public class LlmPreferenceInitializer extends AbstractPreferenceInitializer {
         defaults.putBoolean(PeonConstants.PREF_SEND_THINKING_ENABLED, DEFAULT.isSendThinkingEnabled());
         defaults.put(PeonConstants.PREF_API_KEY, StringUtil.stripToEmpty(DEFAULT.getApiKey()));
         defaults.put(PeonConstants.PREF_SKILL_DIRECTORY, StringUtil.stripToEmpty(DEFAULT.getSkillDirectory()));
+        defaults.put(PeonConstants.PREF_COMMAND_DIRECTORY, StringUtil.stripToEmpty(DEFAULT.getCommandDirectory()));
         defaults.putBoolean(PeonConstants.PREF_DISK_TOOLS_ENABLED, false);
         defaults.put(PeonConstants.PREF_SHELL_CONFIRMATION_ENABLED, "");
     }
@@ -40,23 +41,8 @@ public class LlmPreferenceInitializer extends AbstractPreferenceInitializer {
     public static LlmConfig buildWithDefaults() {
         var prefs = InstanceScope.INSTANCE.getNode(PeonConstants.PLUGIN_ID);
 
-        var skillDir = prefs.get(PeonConstants.PREF_SKILL_DIRECTORY, "");
-        if (StringUtil.hasValue(skillDir) && !Files.isDirectory(Path.of(skillDir))) {
-            var dir = EclipseUtil.resolveInEclipse(skillDir);
-            if (dir.isPresent()) {
-                var resource = dir.get();
-                // save Eclipse workspace-relative path to prefs (portable)
-                prefs.put(PeonConstants.PREF_SKILL_DIRECTORY, resource.getFullPath().toOSString());
-                var abs = JdtUtil.diskPathOf(resource);
-                if (abs != null) {
-                    LOG.info("Resolved skill dir " + skillDir + " as " + abs);
-                    skillDir = abs;
-                } else {
-                    LOG.warn("Could not resolve skill dir to a filesystem path for " + resource.getFullPath());
-                    skillDir = "";
-                }
-            }
-        }
+        var skillDir = resolveDirPreference(prefs, PeonConstants.PREF_SKILL_DIRECTORY, "skill");
+        var commandDir = resolveDirPreference(prefs, PeonConstants.PREF_COMMAND_DIRECTORY, "command");
 
         return LlmConfig.builder()
             .providerType(AiProvider.parse(prefs.get(PeonConstants.PREF_PROVIDER_TYPE, DEFAULT.getProviderType().name())))
@@ -67,8 +53,35 @@ public class LlmPreferenceInitializer extends AbstractPreferenceInitializer {
             .sendThinkingEnabled(prefs.getBoolean(PeonConstants.PREF_SEND_THINKING_ENABLED, DEFAULT.isSendThinkingEnabled()))
             .apiKey(prefs.get(PeonConstants.PREF_API_KEY, ""))
             .skillDirectory(skillDir)
+            .commandDirectory(commandDir)
             .diskToolsEnabled(prefs.getBoolean(PeonConstants.PREF_DISK_TOOLS_ENABLED, false))
             .build();
+    }
+
+    /**
+     * Returns an absolute filesystem path for the directory preference. If the stored value is
+     * not already an absolute directory, attempts to resolve it as an Eclipse workspace-relative
+     * resource and rewrites the preference to the portable workspace path on success.
+     */
+    private static String resolveDirPreference(org.eclipse.core.runtime.preferences.IEclipsePreferences prefs,
+            String key, String label) {
+        var dirValue = prefs.get(key, "");
+        if (StringUtil.hasValue(dirValue) && !Files.isDirectory(Path.of(dirValue))) {
+            var dir = EclipseUtil.resolveInEclipse(dirValue);
+            if (dir.isPresent()) {
+                var resource = dir.get();
+                prefs.put(key, resource.getFullPath().toOSString());
+                var abs = JdtUtil.diskPathOf(resource);
+                if (abs != null) {
+                    LOG.info("Resolved " + label + " dir " + dirValue + " as " + abs);
+                    dirValue = abs;
+                } else {
+                    LOG.warn("Could not resolve " + label + " dir to a filesystem path for " + resource.getFullPath());
+                    dirValue = "";
+                }
+            }
+        }
+        return dirValue;
     }
     
     public static void setModel(String model) {

--- a/org.sterl.llmpeon/src/org/sterl/llmpeon/parts/widget/SlashMenuPopup.java
+++ b/org.sterl.llmpeon/src/org/sterl/llmpeon/parts/widget/SlashMenuPopup.java
@@ -1,0 +1,224 @@
+package org.sterl.llmpeon.parts.widget;
+
+import java.util.List;
+import java.util.Locale;
+import java.util.function.Consumer;
+
+import org.eclipse.swt.SWT;
+import org.eclipse.swt.events.PaintListener;
+import org.eclipse.swt.graphics.Point;
+import org.eclipse.swt.graphics.Rectangle;
+import org.eclipse.swt.layout.FillLayout;
+import org.eclipse.swt.widgets.Composite;
+import org.eclipse.swt.widgets.Control;
+import org.eclipse.swt.widgets.Display;
+import org.eclipse.swt.widgets.Listener;
+import org.eclipse.swt.widgets.Shell;
+import org.eclipse.swt.widgets.Table;
+import org.eclipse.swt.widgets.TableColumn;
+import org.eclipse.swt.widgets.TableItem;
+import org.sterl.llmpeon.command.CommandRecord;
+
+/**
+ * Lightweight popup that lists slash-commands matching the current prefix.
+ *
+ * <p>The popup is a borderless on-top {@link Shell} anchored to the chat input. It never takes
+ * focus; the host widget keeps focus on its text control and forwards arrow / Enter / Escape
+ * keys via {@link #moveSelection(int)}, {@link #commitSelection()} and {@link #hide()}.</p>
+ */
+public class SlashMenuPopup {
+
+    /** Maximum rows shown without scrolling. */
+    private static final int MAX_VISIBLE_ROWS = 8;
+    /** Minimum popup width in pixels. */
+    private static final int MIN_WIDTH = 240;
+    /** Maximum popup width in pixels. */
+    private static final int MAX_WIDTH = 520;
+
+    private final Composite anchor;
+    private final Consumer<CommandRecord> onSelect;
+    private final Listener anchorShellMoveListener;
+    private final Shell anchorShell;
+
+    private Shell popup;
+    private Table table;
+    private List<CommandRecord> filtered = List.of();
+    private List<CommandRecord> source = List.of();
+    private String currentPrefix = "";
+
+    public SlashMenuPopup(Composite anchor, Consumer<CommandRecord> onSelect) {
+        this.anchor = anchor;
+        this.onSelect = onSelect;
+        this.anchorShell = anchor.getShell();
+        this.anchorShellMoveListener = event -> {
+            if (isOpen()) hide();
+        };
+        anchorShell.addListener(SWT.Move, anchorShellMoveListener);
+        anchorShell.addListener(SWT.Resize, anchorShellMoveListener);
+
+        anchor.addDisposeListener(e -> {
+            if (!anchorShell.isDisposed()) {
+                anchorShell.removeListener(SWT.Move, anchorShellMoveListener);
+                anchorShell.removeListener(SWT.Resize, anchorShellMoveListener);
+            }
+            hide();
+        });
+    }
+
+    public boolean isOpen() {
+        return popup != null && !popup.isDisposed() && popup.isVisible();
+    }
+
+    /**
+     * Shows or refreshes the popup with the given commands filtered by {@code prefix}.
+     * If no commands match, the popup is hidden.
+     *
+     * @param commands     full list of available commands
+     * @param prefix       prefix already typed after the slash, may be empty
+     * @param anchorScreen anchor position in display coordinates (typically the caret location)
+     */
+    public void show(List<CommandRecord> commands, String prefix, Point anchorScreen) {
+        this.source = commands == null ? List.of() : commands;
+        this.currentPrefix = prefix == null ? "" : prefix;
+        var matches = filter(this.source, this.currentPrefix);
+        if (matches.isEmpty()) {
+            hide();
+            return;
+        }
+        this.filtered = matches;
+        ensurePopup();
+        rebuildItems();
+        layoutAt(anchorScreen);
+        popup.setVisible(true);
+    }
+
+    /** Updates the prefix filter while the popup is visible. */
+    public void updatePrefix(String prefix) {
+        this.currentPrefix = prefix == null ? "" : prefix;
+        if (popup == null || popup.isDisposed()) return;
+        var matches = filter(source, currentPrefix);
+        if (matches.isEmpty()) {
+            hide();
+            return;
+        }
+        this.filtered = matches;
+        rebuildItems();
+    }
+
+    /** Moves selection by {@code delta} rows; wraps at boundaries. */
+    public void moveSelection(int delta) {
+        if (!isOpen() || filtered.isEmpty()) return;
+        int idx = table.getSelectionIndex();
+        if (idx < 0) idx = 0;
+        int next = (idx + delta) % filtered.size();
+        if (next < 0) next += filtered.size();
+        table.setSelection(next);
+        table.showSelection();
+    }
+
+    /** Triggers the consumer with the currently selected command, then hides the popup. */
+    public boolean commitSelection() {
+        if (!isOpen() || filtered.isEmpty()) return false;
+        int idx = table.getSelectionIndex();
+        if (idx < 0) idx = 0;
+        var selected = filtered.get(idx);
+        hide();
+        onSelect.accept(selected);
+        return true;
+    }
+
+    public void hide() {
+        if (popup != null && !popup.isDisposed()) {
+            popup.setVisible(false);
+            popup.dispose();
+        }
+        popup = null;
+        table = null;
+        filtered = List.of();
+    }
+
+    private void ensurePopup() {
+        if (popup != null && !popup.isDisposed()) return;
+
+        popup = new Shell(anchorShell, SWT.NO_TRIM | SWT.ON_TOP | SWT.TOOL);
+        popup.setLayout(new FillLayout());
+
+        table = new Table(popup, SWT.SINGLE | SWT.FULL_SELECTION | SWT.V_SCROLL);
+        table.setHeaderVisible(false);
+        table.setLinesVisible(false);
+        var col = new TableColumn(table, SWT.LEFT);
+        col.setWidth(MAX_WIDTH);
+
+        table.addListener(SWT.MouseDoubleClick, e -> commitSelection());
+        table.addListener(SWT.DefaultSelection, e -> commitSelection());
+
+        PaintListener border = e -> {
+            var size = popup.getSize();
+            e.gc.setForeground(Display.getDefault().getSystemColor(SWT.COLOR_WIDGET_BORDER));
+            e.gc.drawRectangle(0, 0, size.x - 1, size.y - 1);
+        };
+        popup.addPaintListener(border);
+    }
+
+    private void rebuildItems() {
+        table.removeAll();
+        for (CommandRecord cmd : filtered) {
+            var item = new TableItem(table, SWT.NONE);
+            item.setText(formatRow(cmd));
+        }
+        if (!filtered.isEmpty()) {
+            table.setSelection(0);
+        }
+    }
+
+    private void layoutAt(Point anchorScreen) {
+        int rows = Math.min(filtered.size(), MAX_VISIBLE_ROWS);
+        int rowHeight = table.getItemHeight();
+        if (rowHeight <= 0) rowHeight = 18;
+        int height = rowHeight * rows + 6;
+
+        int width = Math.max(MIN_WIDTH, Math.min(MAX_WIDTH, anchor.getSize().x));
+        table.getColumn(0).setWidth(width - 4);
+
+        var bounds = new Rectangle(0, 0, width, height);
+        if (anchorScreen != null) {
+            bounds.x = anchorScreen.x;
+            bounds.y = anchorScreen.y - height; // above the caret
+            if (bounds.y < 0) bounds.y = anchorScreen.y + 16; // fall back below
+        }
+        // Clamp to the monitor that contains the anchor.
+        var monitorBounds = anchorShell.getMonitor().getClientArea();
+        if (bounds.x + bounds.width > monitorBounds.x + monitorBounds.width) {
+            bounds.x = monitorBounds.x + monitorBounds.width - bounds.width;
+        }
+        if (bounds.x < monitorBounds.x) bounds.x = monitorBounds.x;
+        if (bounds.y < monitorBounds.y) bounds.y = monitorBounds.y;
+        popup.setBounds(bounds);
+    }
+
+    private static String formatRow(CommandRecord cmd) {
+        if (cmd.description() == null || cmd.description().isBlank()) {
+            return "/" + cmd.name();
+        }
+        return "/" + cmd.name() + "  \u2014  " + cmd.description();
+    }
+
+    private static List<CommandRecord> filter(List<CommandRecord> source, String prefix) {
+        if (prefix == null || prefix.isEmpty()) return source;
+        var lower = prefix.toLowerCase(Locale.ROOT);
+        return source.stream()
+                .filter(c -> c.name().toLowerCase(Locale.ROOT).startsWith(lower))
+                .toList();
+    }
+
+    /** Detach the anchor-shell listeners and dispose the popup if alive. */
+    public void dispose() {
+        if (!anchorShell.isDisposed()) {
+            anchorShell.removeListener(SWT.Move, anchorShellMoveListener);
+            anchorShell.removeListener(SWT.Resize, anchorShellMoveListener);
+        }
+        hide();
+    }
+
+    Control getPopupShellForTests() { return popup; }
+}

--- a/org.sterl.llmpeon/src/org/sterl/llmpeon/parts/widget/TextInputWidget.java
+++ b/org.sterl.llmpeon/src/org/sterl/llmpeon/parts/widget/TextInputWidget.java
@@ -2,6 +2,7 @@ package org.sterl.llmpeon.parts.widget;
 
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.custom.StyledText;
+import org.eclipse.swt.custom.VerifyKeyListener;
 import org.eclipse.swt.events.KeyListener;
 import org.eclipse.swt.events.ModifyListener;
 import org.eclipse.swt.graphics.Color;
@@ -86,8 +87,24 @@ public class TextInputWidget extends Composite {
         styledText.addKeyListener(listener);
     }
 
+    /**
+     * Adds a verify-key listener that runs BEFORE the StyledText consumes the key. Setting
+     * {@code event.doit = false} suppresses the default behavior (e.g. arrow navigation). This is
+     * the only reliable hook for stealing arrow / Enter keys to drive an external popup.
+     */
+    public void addVerifyKeyListener(VerifyKeyListener listener) {
+        styledText.addVerifyKeyListener(listener);
+    }
+
     /** Sets the background on the underlying StyledText (safe — not a Composite). */
     public void setTextBackground(Color color) {
         styledText.setBackground(color);
+    }
+
+    /** Display coordinates of the current caret, suitable for anchoring an external popup. */
+    public Point getCaretDisplayLocation() {
+        if (styledText.isDisposed()) return null;
+        var local = styledText.getLocationAtOffset(styledText.getCaretOffset());
+        return styledText.toDisplay(local.x, local.y);
     }
 }

--- a/org.sterl.llmpeon/src/org/sterl/llmpeon/parts/widget/UserInputWidget.java
+++ b/org.sterl.llmpeon/src/org/sterl/llmpeon/parts/widget/UserInputWidget.java
@@ -1,5 +1,8 @@
 package org.sterl.llmpeon.parts.widget;
 
+import java.util.List;
+import java.util.function.Supplier;
+
 import org.eclipse.debug.ui.DebugUITools;
 import org.eclipse.debug.ui.IDebugUIConstants;
 import org.eclipse.swt.SWT;
@@ -11,6 +14,7 @@ import org.eclipse.swt.layout.GridLayout;
 import org.eclipse.swt.widgets.Button;
 import org.eclipse.swt.widgets.Composite;
 import org.eclipse.swt.widgets.Control;
+import org.sterl.llmpeon.command.CommandRecord;
 import org.sterl.llmpeon.parts.shared.ImageUtil;
 import org.sterl.llmpeon.parts.shared.SwtUtil;
 
@@ -36,6 +40,9 @@ public class UserInputWidget extends Composite {
     private final Runnable onMicClick;
 
     private final Color colorRecording;
+
+    private SlashMenuPopup slashPopup;
+    private Supplier<List<CommandRecord>> commandSupplier;
 
     public UserInputWidget(Composite parent, int style, Runnable onSend, Runnable onStop, Runnable onMicClick) {
         super(parent, style);
@@ -83,6 +90,42 @@ public class UserInputWidget extends Composite {
                 }
             }
         }));
+
+        // Refresh the slash popup on every modification so it tracks the current prefix.
+        textInput.addModifyListener(e -> refreshSlashPopup());
+
+        // Steal arrow / Enter / Escape ONLY while the slash popup is open. Plain Enter still
+        // produces a newline in StyledText when the popup is closed.
+        textInput.addVerifyKeyListener(e -> {
+            if (slashPopup == null || !slashPopup.isOpen()) return;
+            switch (e.keyCode) {
+            case SWT.ARROW_DOWN:
+                slashPopup.moveSelection(1);
+                e.doit = false;
+                break;
+            case SWT.ARROW_UP:
+                slashPopup.moveSelection(-1);
+                e.doit = false;
+                break;
+            case SWT.ESC:
+                slashPopup.hide();
+                e.doit = false;
+                break;
+            case SWT.CR:
+            case SWT.LF:
+            case SWT.KEYPAD_CR:
+                // Plain Enter commits the selection; Ctrl/Cmd+Enter still sends the message.
+                if ((e.stateMask & (SWT.CTRL | SWT.COMMAND)) == 0) {
+                    if (slashPopup.commitSelection()) e.doit = false;
+                }
+                break;
+            case SWT.TAB:
+                if (slashPopup.commitSelection()) e.doit = false;
+                break;
+            default:
+                break;
+            }
+        });
 
         // Right icon column — mic on top (optional), send/stop at bottom
         rightColumn = new Composite(textRow, SWT.NONE);
@@ -179,5 +222,84 @@ public class UserInputWidget extends Composite {
     @Override
     public boolean setFocus() {
         return textInput.setFocus();
+    }
+
+    /** Hides the slash-command popup if it is currently shown. Safe to call any time. */
+    public void dismissSlashMenu() {
+        if (slashPopup != null) slashPopup.hide();
+    }
+
+    /**
+     * Enables the slash-command popup. {@code commandSupplier} returns the currently loaded
+     * commands. Pass {@code null} to disable the popup.
+     */
+    public void enableSlashCommands(Supplier<List<CommandRecord>> commandSupplier) {
+        this.commandSupplier = commandSupplier;
+        if (commandSupplier == null) {
+            disposeSlashPopup();
+            return;
+        }
+        if (slashPopup == null) {
+            slashPopup = new SlashMenuPopup(this, this::applyCommandSelection);
+            addDisposeListener(e -> disposeSlashPopup());
+        }
+    }
+
+    private void refreshSlashPopup() {
+        if (commandSupplier == null || slashPopup == null) return;
+        var text = textInput.getText();
+        // Trigger policy: only while the user is still typing the FIRST token, which must
+        // start with '/' at offset 0. Once any whitespace appears, the popup hides — the user
+        // has moved on to the message body (e.g. "/foo extra text").
+        if (text == null || !text.startsWith("/")) {
+            slashPopup.hide();
+            return;
+        }
+        for (int i = 1; i < text.length(); i++) {
+            if (Character.isWhitespace(text.charAt(i))) {
+                slashPopup.hide();
+                return;
+            }
+        }
+        var prefix = extractPrefix(text);
+        var commands = commandSupplier.get();
+        if (commands == null || commands.isEmpty()) {
+            slashPopup.hide();
+            return;
+        }
+        var caret = textInput.getCaretDisplayLocation();
+        slashPopup.show(commands, prefix, caret);
+    }
+
+    private static String extractPrefix(String text) {
+        // Read characters after the leading '/' until whitespace.
+        var sb = new StringBuilder();
+        for (int i = 1; i < text.length(); i++) {
+            char c = text.charAt(i);
+            if (Character.isWhitespace(c)) break;
+            sb.append(c);
+        }
+        return sb.toString();
+    }
+
+    private void applyCommandSelection(CommandRecord cmd) {
+        var current = textInput.getText();
+        var afterToken = "";
+        if (current != null && current.startsWith("/")) {
+            int wsIdx = -1;
+            for (int i = 1; i < current.length(); i++) {
+                if (Character.isWhitespace(current.charAt(i))) { wsIdx = i; break; }
+            }
+            if (wsIdx >= 0) afterToken = current.substring(wsIdx);
+        }
+        textInput.setText("/" + cmd.name() + (afterToken.isEmpty() ? " " : afterToken));
+        textInput.setFocus();
+    }
+
+    private void disposeSlashPopup() {
+        if (slashPopup != null) {
+            slashPopup.dispose();
+            slashPopup = null;
+        }
     }
 }


### PR DESCRIPTION
<img width="1280" height="152" alt="스크린샷 2026-05-18 20 25 08" src="https://github.com/user-attachments/assets/7396f824-ea2e-48de-b7df-a78c9c317537" />

<img width="1079" height="574" alt="스크린샷 2026-05-18 20 26 45" src="https://github.com/user-attachments/assets/d633fb64-003e-40d2-b1ba-22cabc9d9360" />

### [issue #35](https://github.com/sterlp/eclipse-peon-ai/issues/35) — slash commands

- Adds a commands directory (preferences), loads each top-level *.md as a /command, shows a popup while you type /…, and on send replaces the next turn’s system prompt with that file’s body (optional YAML description: only). Tool rules stay per mode (PLAN/DEV/AGENT as before).

- Skill list / discovery ([#34](https://github.com/sterlp/eclipse-peon-ai/issues/34)) is not in this PR—planned as a small follow-up.

### Summary of changes

- **Preferences:** new “Commands directory” field; path resolution matches the existing skills directory behavior (including workspace-relative paths).

- **Core:** CommandService / CommandRecord scan the directory for *.md, optional frontmatter description, command name = file stem; unit tests for loading and edge cases.

- **Config:** LlmConfig.commandDirectory plumbed through preferences and PeonAiService refresh on config change.

- **Chat UI:** SlashMenuPopup anchored near the caret; UserInputWidget shows suggestions only while the first token after / is being typed (no popup once whitespace separates the command from the rest of the message).

- **Invocation:** AIChatView parses /name …; unknown names show an error and abort send; known commands set AbstractChatService.setOneShotSystemPrompt so the next request uses the command body (with ${…} template expansion) instead of the default system prompt for that single turn.

- **Build:** Lombok annotationProcessorPaths in org.sterl.llmpeon.core for reliable annotation processing on recent JDKs; optional VS Code Java null-analysis setting.