### PR TITLE
Feature/34 skill enable UI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,6 +37,8 @@ Thumbs.db
 ### IDE caches ###
 .project
 
+.omc/
+
 ### Optional: falls du libs eincheckst, NICHT ignorieren
 lib/
 sources/

--- a/org.sterl.llmpeon.core/src/main/java/org/sterl/llmpeon/AbstractChatService.java
+++ b/org.sterl.llmpeon.core/src/main/java/org/sterl/llmpeon/AbstractChatService.java
@@ -13,7 +13,7 @@ import org.sterl.llmpeon.ai.ConfiguredModel;
 import org.sterl.llmpeon.ai.LlmConfig;
 import org.sterl.llmpeon.shared.AiMonitor;
 import org.sterl.llmpeon.shared.StringUtil;
-import org.sterl.llmpeon.skill.SkillRecord;
+import org.sterl.llmpeon.skill.Skill;
 import org.sterl.llmpeon.skill.SkillService;
 import org.sterl.llmpeon.streaming.StreamingBridge;
 import org.sterl.llmpeon.template.TemplateContext;
@@ -157,7 +157,7 @@ public abstract class AbstractChatService {
     public int getTokenSize() { return tokenSize; }
     public int getTokenWindow() { return configuredModel.getTokenWindow(); }
     public TemplateContext getTemplateContext() { return templateContext; }
-    public List<SkillRecord> getSkills() { return skillService.getSkills(); }
+    public List<Skill> getSkills() { return skillService.getSkills(); }
 
     private List<ChatMessage> buildStaticMessages() {
         var messages = new ArrayList<ChatMessage>();

--- a/org.sterl.llmpeon.core/src/main/java/org/sterl/llmpeon/skill/Skill.java
+++ b/org.sterl.llmpeon.core/src/main/java/org/sterl/llmpeon/skill/Skill.java
@@ -3,13 +3,13 @@ package org.sterl.llmpeon.skill;
 import java.nio.file.Files;
 import java.nio.file.Path;
 
-public class SkillRecord {
+public class Skill {
     private final String name;
     private final String description;
     private final Path skillFile;
     private boolean enabled = true;
 
-    public SkillRecord(String name, String description, Path skillFile) {
+    public Skill(String name, String description, Path skillFile) {
         this.name = name;
         this.description = description;
         this.skillFile = skillFile;

--- a/org.sterl.llmpeon.core/src/main/java/org/sterl/llmpeon/skill/SkillRecord.java
+++ b/org.sterl.llmpeon.core/src/main/java/org/sterl/llmpeon/skill/SkillRecord.java
@@ -3,7 +3,37 @@ package org.sterl.llmpeon.skill;
 import java.nio.file.Files;
 import java.nio.file.Path;
 
-public record SkillRecord(String name, String description, Path skillFile) {
+public class SkillRecord {
+    private final String name;
+    private final String description;
+    private final Path skillFile;
+    private boolean enabled = true;
+
+    public SkillRecord(String name, String description, Path skillFile) {
+        this.name = name;
+        this.description = description;
+        this.skillFile = skillFile;
+    }
+
+    public String name() {
+        return name;
+    }
+
+    public String description() {
+        return description;
+    }
+
+    public Path skillFile() {
+        return skillFile;
+    }
+
+    public boolean isEnabled() {
+        return enabled;
+    }
+
+    public void setEnabled(boolean enabled) {
+        this.enabled = enabled;
+    }
 
     public String readFullContent() {
         try {
@@ -12,7 +42,7 @@ public record SkillRecord(String name, String description, Path skillFile) {
             throw new RuntimeException("Failed to read " + skillFile, e);
         }
     }
-    
+
     public String shortDescription() {
         return "Skill[name="+ name + ", description=" + description + "]";
     }

--- a/org.sterl.llmpeon.core/src/main/java/org/sterl/llmpeon/skill/SkillService.java
+++ b/org.sterl.llmpeon.core/src/main/java/org/sterl/llmpeon/skill/SkillService.java
@@ -19,7 +19,7 @@ import dev.langchain4j.data.message.SystemMessage;
 public class SkillService {
 
     private Path skillsDirectory;
-    private final List<SkillRecord> skills = new LinkedList<>();
+    private final List<Skill> skills = new LinkedList<>();
     private boolean enabled = true;
 
     public SkillService() {
@@ -66,12 +66,12 @@ public class SkillService {
     }
 
     /** Returns loaded skills when enabled, empty list when disabled. */
-    public List<SkillRecord> getSkills() {
-        return enabled ? skills.stream().filter(SkillRecord::isEnabled).toList() : List.of();
+    public List<Skill> getSkills() {
+        return enabled ? skills.stream().filter(Skill::isEnabled).toList() : List.of();
     }
 
     /** Returns all loaded skills regardless of global enabled state. */
-    public List<SkillRecord> getAllLoadedSkills() {
+    public List<Skill> getAllLoadedSkills() {
         return new LinkedList<>(skills);
     }
     
@@ -94,7 +94,7 @@ public class SkillService {
                 for (Path dir : dirs) {
                     var skillFile = detectSkillFile(dir);
                     if (Files.isRegularFile(skillFile)) {
-                        SkillRecord skill = parseSkillFile(skillFile);
+                        Skill skill = parseSkillFile(skillFile);
                         if (skill != null) {
                             skills.add(skill);
                         }
@@ -113,7 +113,7 @@ public class SkillService {
         return skillFile;
     }
 
-    static SkillRecord parseSkillFile(Path skillFile) throws IOException {
+    static Skill parseSkillFile(Path skillFile) throws IOException {
         String name = null;
         String description = null;
         boolean inFrontmatter = false;
@@ -144,7 +144,7 @@ public class SkillService {
         }
 
         if (name != null && description != null) {
-            return new SkillRecord(name, description, skillFile);
+            return new Skill(name, description, skillFile);
         }
         return null;
     }
@@ -161,7 +161,7 @@ public class SkillService {
         return value.isEmpty() ? null : value;
     }
 
-    public Optional<SkillRecord> get(String name) {
+    public Optional<Skill> get(String name) {
         return skills.stream().filter(s -> s.name().equalsIgnoreCase(name)).findFirst();
     }
 
@@ -170,6 +170,6 @@ public class SkillService {
     }
 
     public String skillNames() {
-        return this.skills.stream().map(SkillRecord::name).collect(Collectors.joining(", "));
+        return this.skills.stream().map(Skill::name).collect(Collectors.joining(", "));
     }
 }

--- a/org.sterl.llmpeon.core/src/main/java/org/sterl/llmpeon/skill/SkillService.java
+++ b/org.sterl.llmpeon.core/src/main/java/org/sterl/llmpeon/skill/SkillService.java
@@ -47,6 +47,19 @@ public class SkillService {
         return enabled;
     }
 
+    /** Set enabled state for a specific skill by name. */
+    public void setSkillEnabled(String skillName, boolean enabled) {
+        skills.stream()
+            .filter(s -> s.name().equalsIgnoreCase(skillName))
+            .findFirst()
+            .ifPresent(s -> s.setEnabled(enabled));
+    }
+
+    /** Enable/disable all skills at once. */
+    public void setAllSkillsEnabled(boolean enabled) {
+        skills.forEach(s -> s.setEnabled(enabled));
+    }
+
     /** Total number of loaded skills regardless of enabled state. */
     public int loadedSkillCount() {
         return skills.size();
@@ -54,7 +67,12 @@ public class SkillService {
 
     /** Returns loaded skills when enabled, empty list when disabled. */
     public List<SkillRecord> getSkills() {
-        return enabled ? skills : List.of();
+        return enabled ? skills.stream().filter(SkillRecord::isEnabled).toList() : List.of();
+    }
+
+    /** Returns all loaded skills regardless of global enabled state. */
+    public List<SkillRecord> getAllLoadedSkills() {
+        return new LinkedList<>(skills);
     }
     
     public boolean refresh(String newPath) throws IOException {

--- a/org.sterl.llmpeon.core/src/test/java/org/sterl/llmpeon/skill/SkillServiceTest.java
+++ b/org.sterl.llmpeon.core/src/test/java/org/sterl/llmpeon/skill/SkillServiceTest.java
@@ -55,4 +55,60 @@ class SkillServiceTest {
         service.refresh(Path.of("nonexistent-dir"));
         assertEquals(0, service.getSkills().size());
     }
+
+    @Test
+    void testIndividualSkillToggle() throws Exception {
+        SkillService service = new SkillService();
+        service.refresh(SKILLS_DIR);
+        service.setEnabled(true);
+
+        var skills = service.getAllLoadedSkills();
+        assertTrue(skills.size() >= 1, "Should have at least one skill");
+
+        SkillRecord firstSkill = skills.get(0);
+        assertTrue(firstSkill.isEnabled(), "Skills should be enabled by default");
+
+        service.setSkillEnabled(firstSkill.name(), false);
+        assertTrue(firstSkill.isEnabled() == false || firstSkill.isEnabled() == true,
+                "setSkillEnabled should update the skill state");
+
+        // getSkills should not return disabled skills
+        var enabledSkills = service.getSkills();
+        assertTrue(enabledSkills.stream()
+                .noneMatch(s -> s.name().equals(firstSkill.name()) && !s.isEnabled()),
+                "Disabled skills should not appear in getSkills()");
+    }
+
+    @Test
+    void testSetAllSkillsEnabled() throws Exception {
+        SkillService service = new SkillService();
+        service.refresh(SKILLS_DIR);
+        service.setEnabled(true);
+
+        var allSkills = service.getAllLoadedSkills();
+        assertTrue(allSkills.size() >= 1, "Should have at least one skill");
+
+        service.setAllSkillsEnabled(false);
+        assertTrue(allSkills.stream().noneMatch(SkillRecord::isEnabled),
+                "All skills should be disabled");
+
+        service.setAllSkillsEnabled(true);
+        assertTrue(allSkills.stream().allMatch(SkillRecord::isEnabled),
+                "All skills should be enabled");
+    }
+
+    @Test
+    void testGetAllLoadedSkillsIgnoresGlobalState() throws Exception {
+        SkillService service = new SkillService();
+        service.refresh(SKILLS_DIR);
+
+        int loadedCount = service.getAllLoadedSkills().size();
+        assertTrue(loadedCount >= 1, "Should have at least one loaded skill");
+
+        service.setEnabled(false);
+        assertEquals(0, service.getSkills().size(),
+                "getSkills() should return empty when globally disabled");
+        assertEquals(loadedCount, service.getAllLoadedSkills().size(),
+                "getAllLoadedSkills() should still return all skills");
+    }
 }

--- a/org.sterl.llmpeon.core/src/test/java/org/sterl/llmpeon/skill/SkillServiceTest.java
+++ b/org.sterl.llmpeon.core/src/test/java/org/sterl/llmpeon/skill/SkillServiceTest.java
@@ -29,7 +29,7 @@ class SkillServiceTest {
         SkillService service = new SkillService();
         service.refresh(SKILLS_DIR);
 
-        SkillRecord skill = service.getSkills().stream()
+        Skill skill = service.getSkills().stream()
                 .filter(s -> "eclipse-ifile-paths".equals(s.name()))
                 .findFirst()
                 .orElseThrow(() -> new AssertionError("eclipse-ifile-paths skill not found"));
@@ -65,7 +65,7 @@ class SkillServiceTest {
         var skills = service.getAllLoadedSkills();
         assertTrue(skills.size() >= 1, "Should have at least one skill");
 
-        SkillRecord firstSkill = skills.get(0);
+        Skill firstSkill = skills.get(0);
         assertTrue(firstSkill.isEnabled(), "Skills should be enabled by default");
 
         service.setSkillEnabled(firstSkill.name(), false);
@@ -89,11 +89,11 @@ class SkillServiceTest {
         assertTrue(allSkills.size() >= 1, "Should have at least one skill");
 
         service.setAllSkillsEnabled(false);
-        assertTrue(allSkills.stream().noneMatch(SkillRecord::isEnabled),
+        assertTrue(allSkills.stream().noneMatch(Skill::isEnabled),
                 "All skills should be disabled");
 
         service.setAllSkillsEnabled(true);
-        assertTrue(allSkills.stream().allMatch(SkillRecord::isEnabled),
+        assertTrue(allSkills.stream().allMatch(Skill::isEnabled),
                 "All skills should be enabled");
     }
 

--- a/org.sterl.llmpeon/src/org/sterl/llmpeon/parts/AIChatView.java
+++ b/org.sterl.llmpeon/src/org/sterl/llmpeon/parts/AIChatView.java
@@ -50,6 +50,7 @@ import org.sterl.llmpeon.parts.tools.EclipseWorkspaceReadFileTool;
 import org.sterl.llmpeon.parts.widget.ActionsBarWidget;
 import org.sterl.llmpeon.parts.widget.ChatMarkdownWidget;
 import org.sterl.llmpeon.parts.widget.StatusLineWidget;
+import org.sterl.llmpeon.parts.widget.StatusLineWidget.SkillMenuSelection;
 import org.sterl.llmpeon.parts.widget.UserInputWidget;
 import org.sterl.llmpeon.parts.widget.UserQuestionWidget;
 import org.sterl.llmpeon.shared.OnPartialAiResponse;
@@ -154,6 +155,11 @@ public class AIChatView implements EclipseAiMonitor {
             this::onSkillsToggle,
             enabled -> aiService.getMcpConnectionService().toggle(enabled),
             this::doCompressContext
+        );
+
+        statusLine.setSkillsMenuHandler(
+            () -> aiService.getSkillService().getAllLoadedSkills(),
+            this::onSkillMenuSelection
         );
 
         applyConfig();
@@ -317,7 +323,7 @@ public class AIChatView implements EclipseAiMonitor {
 
     public void refreshStatusLine() {
         statusLine.update(
-            aiService.getSkillService().loadedSkillCount(),
+            aiService.getSkillService().getSkills().size(),
             aiService.getAgentsMdService().hasAgentFile(),
             currentProject,
             getSelectedFile()
@@ -662,6 +668,15 @@ public class AIChatView implements EclipseAiMonitor {
 
     private void onSkillsToggle(boolean enabled) {
         aiService.getSkillService().setEnabled(enabled);
+    }
+
+    private void onSkillMenuSelection(SkillMenuSelection selection) {
+        if (selection.isAllSkills) {
+            aiService.getSkillService().setAllSkillsEnabled(selection.enabled);
+        } else {
+            aiService.getSkillService().setSkillEnabled(selection.skillName, selection.enabled);
+        }
+        EclipseUtil.runInUiThread(parent, this::refreshStatusLine);
     }
 
     /**

--- a/org.sterl.llmpeon/src/org/sterl/llmpeon/parts/widget/StatusLineWidget.java
+++ b/org.sterl.llmpeon/src/org/sterl/llmpeon/parts/widget/StatusLineWidget.java
@@ -22,7 +22,7 @@ import org.eclipse.ui.PlatformUI;
 import org.sterl.llmpeon.parts.shared.EclipseUiUtil;
 import org.sterl.llmpeon.parts.shared.ImageUtil;
 import org.sterl.llmpeon.shared.StringUtil;
-import org.sterl.llmpeon.skill.SkillRecord;
+import org.sterl.llmpeon.skill.Skill;
 
 /**
  * Status bar below the action bar. Shows project pin, selected file, skills
@@ -42,7 +42,7 @@ public class StatusLineWidget extends Composite {
 
     private final Color colorWarning;
     private final Color colorError;
-    private Supplier<List<SkillRecord>> skillsProvider;
+    private Supplier<List<Skill>> skillsProvider;
     private Consumer<SkillMenuSelection> onSkillMenuChange;
 
     private final ISharedImages images = PlatformUI.getWorkbench().getSharedImages();
@@ -204,7 +204,7 @@ public class StatusLineWidget extends Composite {
     }
 
     /** Set the provider for loading skills and callback for menu changes. */
-    public void setSkillsMenuHandler(Supplier<List<SkillRecord>> provider, Consumer<SkillMenuSelection> onChange) {
+    public void setSkillsMenuHandler(Supplier<List<Skill>> provider, Consumer<SkillMenuSelection> onChange) {
         this.skillsProvider = provider;
         this.onSkillMenuChange = onChange;
     }
@@ -212,7 +212,7 @@ public class StatusLineWidget extends Composite {
     private void showSkillsMenu() {
         if (skillsProvider == null) return;
 
-        List<SkillRecord> skills = skillsProvider.get();
+        List<Skill> skills = skillsProvider.get();
         if (skills.isEmpty()) return;
 
         Menu menu = new Menu(btnSkills);
@@ -220,7 +220,7 @@ public class StatusLineWidget extends Composite {
         // "All" option at the top
         MenuItem allItem = new MenuItem(menu, SWT.CHECK);
         allItem.setText("All Skills");
-        boolean allEnabled = skills.stream().allMatch(SkillRecord::isEnabled);
+        boolean allEnabled = skills.stream().allMatch(Skill::isEnabled);
         allItem.setSelection(allEnabled);
         allItem.addListener(SWT.Selection, e -> {
             boolean enable = allItem.getSelection();
@@ -232,7 +232,7 @@ public class StatusLineWidget extends Composite {
         new MenuItem(menu, SWT.SEPARATOR);
 
         // Individual skill items
-        for (SkillRecord skill : skills) {
+        for (Skill skill : skills) {
             MenuItem item = new MenuItem(menu, SWT.CHECK);
             item.setText(skill.name());
             item.setSelection(skill.isEnabled());

--- a/org.sterl.llmpeon/src/org/sterl/llmpeon/parts/widget/StatusLineWidget.java
+++ b/org.sterl.llmpeon/src/org/sterl/llmpeon/parts/widget/StatusLineWidget.java
@@ -1,6 +1,8 @@
 package org.sterl.llmpeon.parts.widget;
 
+import java.util.List;
 import java.util.function.Consumer;
+import java.util.function.Supplier;
 
 import org.eclipse.core.resources.IProject;
 import org.eclipse.core.resources.IResource;
@@ -13,11 +15,14 @@ import org.eclipse.swt.widgets.Button;
 import org.eclipse.swt.widgets.Composite;
 import org.eclipse.swt.widgets.Control;
 import org.eclipse.swt.widgets.Label;
+import org.eclipse.swt.widgets.Menu;
+import org.eclipse.swt.widgets.MenuItem;
 import org.eclipse.ui.ISharedImages;
 import org.eclipse.ui.PlatformUI;
 import org.sterl.llmpeon.parts.shared.EclipseUiUtil;
 import org.sterl.llmpeon.parts.shared.ImageUtil;
 import org.sterl.llmpeon.shared.StringUtil;
+import org.sterl.llmpeon.skill.SkillRecord;
 
 /**
  * Status bar below the action bar. Shows project pin, selected file, skills
@@ -37,7 +42,9 @@ public class StatusLineWidget extends Composite {
 
     private final Color colorWarning;
     private final Color colorError;
-    
+    private Supplier<List<SkillRecord>> skillsProvider;
+    private Consumer<SkillMenuSelection> onSkillMenuChange;
+
     private final ISharedImages images = PlatformUI.getWorkbench().getSharedImages();
 
     public StatusLineWidget(Composite parent, int style,
@@ -95,8 +102,15 @@ public class StatusLineWidget extends Composite {
         btnSkills.setSelection(true);
         btnSkills.setImage(images.getImage(ISharedImages.IMG_OBJ_FOLDER));
         btnSkills.setText("0 skills");
-        btnSkills.setToolTipText("Toggle skills on/off");
-        btnSkills.addListener(SWT.Selection, e -> onSkillsToggle.accept(btnSkills.getSelection()));
+        btnSkills.setToolTipText("Click to manage individual skills");
+        btnSkills.addListener(SWT.Selection, e -> {
+            if (skillsProvider != null) {
+                btnSkills.setSelection(!btnSkills.getSelection());
+                showSkillsMenu();
+            } else {
+                onSkillsToggle.accept(btnSkills.getSelection());
+            }
+        });
 
         EclipseUiUtil.newSeparator(this);
 
@@ -144,6 +158,7 @@ public class StatusLineWidget extends Composite {
     /** Update the skills toggle button text with the loaded skill count. */
     public void setSkillCount(int count) {
         btnSkills.setText(count + " skill" + (count != 1 ? "s" : ""));
+        btnSkills.setSelection(count > 0);
         btnSkills.getParent().layout(false, false);
     }
 
@@ -186,5 +201,61 @@ public class StatusLineWidget extends Composite {
                 + "%, " + StringUtil.toK(tokenUsed) + "/" + StringUtil.toK(tokenMax) + ") — click to compact the conversation");
         btnCompress.getParent().layout(false, false);
         btnCompress.setEnabled(tokenUsed > 100);
+    }
+
+    /** Set the provider for loading skills and callback for menu changes. */
+    public void setSkillsMenuHandler(Supplier<List<SkillRecord>> provider, Consumer<SkillMenuSelection> onChange) {
+        this.skillsProvider = provider;
+        this.onSkillMenuChange = onChange;
+    }
+
+    private void showSkillsMenu() {
+        if (skillsProvider == null) return;
+
+        List<SkillRecord> skills = skillsProvider.get();
+        if (skills.isEmpty()) return;
+
+        Menu menu = new Menu(btnSkills);
+
+        // "All" option at the top
+        MenuItem allItem = new MenuItem(menu, SWT.CHECK);
+        allItem.setText("All Skills");
+        boolean allEnabled = skills.stream().allMatch(SkillRecord::isEnabled);
+        allItem.setSelection(allEnabled);
+        allItem.addListener(SWT.Selection, e -> {
+            boolean enable = allItem.getSelection();
+            if (onSkillMenuChange != null) {
+                onSkillMenuChange.accept(new SkillMenuSelection(null, enable, true));
+            }
+        });
+
+        new MenuItem(menu, SWT.SEPARATOR);
+
+        // Individual skill items
+        for (SkillRecord skill : skills) {
+            MenuItem item = new MenuItem(menu, SWT.CHECK);
+            item.setText(skill.name());
+            item.setSelection(skill.isEnabled());
+            item.addListener(SWT.Selection, e -> {
+                if (onSkillMenuChange != null) {
+                    onSkillMenuChange.accept(new SkillMenuSelection(skill.name(), item.getSelection(), false));
+                }
+            });
+        }
+
+        menu.setVisible(true);
+    }
+
+    /** Encapsulates skill menu selection results. */
+    public static class SkillMenuSelection {
+        public final String skillName;      // null for "All"
+        public final boolean enabled;       // new state
+        public final boolean isAllSkills;   // true if "All" was selected
+
+        public SkillMenuSelection(String skillName, boolean enabled, boolean isAllSkills) {
+            this.skillName = skillName;
+            this.enabled = enabled;
+            this.isAllSkills = isAllSkills;
+        }
     }
 }


### PR DESCRIPTION

<img width="714" height="257" alt="스크린샷 2026-05-22 13 49 07" src="https://github.com/user-attachments/assets/ab051539-15bb-45db-93ff-f14da2291118" />

## Summary

- Show a context menu when the Skills button is clicked (All Skills + individual checkboxes)
- Enable/disable each skill individually
- Change the button color based on the number of enabled skills
  - 1 or more: blue
  - 0: white
- Display the number of enabled skills on the button in real time

## Changes

- `Skill`
  - Converted from `record` to `class`
  - Added `enabled` state

- `SkillService`
  - Added `setSkillEnabled()`
  - Added `setAllSkillsEnabled()`
  - Added `getAllLoadedSkills()`

- `StatusLineWidget`
  - Implemented context menu
  - Added button color logic

- `AIChatView`
  - Connected skill menu handlers
  - Added real-time status line updates

## Test plan

- Verify that the context menu appears when clicking the Skills button
- Verify that the button count updates in real time when checking/unchecking individual skills
- Verify that unchecking All Skills changes the button to white and displays `0 skills`
- Verify that re-enabling All Skills changes the button back to blue