### PR TITLE
refactor: rename Skill → SkillPromptFile, CommandRecord → CommandProm…

### DIFF
--- a/.idea/.gitignore
+++ b/.idea/.gitignore
@@ -1,0 +1,8 @@
+# Default ignored files
+/shelf/
+/workspace.xml
+# Editor-based HTTP Client requests
+/httpRequests/
+# Datasource local storage ignored files
+/dataSources/
+/dataSources.local.xml

--- a/.idea/compiler.xml
+++ b/.idea/compiler.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="CompilerConfiguration">
+    <annotationProcessing>
+      <profile name="Maven default annotation processors profile" enabled="true">
+        <sourceOutputDir name="target/generated-sources/annotations" />
+        <sourceTestOutputDir name="target/generated-test-sources/test-annotations" />
+        <outputRelativeToContentRoot value="true" />
+        <module name="org.sterl.llmpeon" />
+        <module name="llmpeon-target" />
+        <module name="llmpeon-update-site" />
+        <module name="llmpeon-feature" />
+      </profile>
+      <profile name="Annotation profile for llmpeon-core" enabled="true">
+        <sourceOutputDir name="target/generated-sources/annotations" />
+        <sourceTestOutputDir name="target/generated-test-sources/test-annotations" />
+        <outputRelativeToContentRoot value="true" />
+        <processorPath useClasspath="false">
+          <entry name="$MAVEN_REPOSITORY$/org/projectlombok/lombok/1.18.44/lombok-1.18.44.jar" />
+        </processorPath>
+        <module name="llmpeon-core" />
+      </profile>
+      <profile name="Annotation profile for llmpeon-parent" enabled="true">
+        <sourceOutputDir name="../generated-sources/annotations" />
+        <sourceTestOutputDir name="../generated-test-sources/test-annotations" />
+        <module name="org.sterl.llmpeon.test" />
+      </profile>
+    </annotationProcessing>
+  </component>
+</project>

--- a/.idea/encodings.xml
+++ b/.idea/encodings.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="Encoding">
+    <file url="file://$PROJECT_DIR$/org.sterl.llmpeon.core/src/main/java" charset="UTF-8" />
+    <file url="file://$PROJECT_DIR$/org.sterl.llmpeon.core/src/main/resources" charset="UTF-8" />
+    <file url="file://$PROJECT_DIR$/org.sterl.llmpeon.test/src/main/java" charset="UTF-8" />
+    <file url="file://$PROJECT_DIR$/org.sterl.llmpeon.test/src/main/resources" charset="UTF-8" />
+    <file url="file://$PROJECT_DIR$/org.sterl.llmpeon/src/main/java" charset="UTF-8" />
+    <file url="file://$PROJECT_DIR$/org.sterl.llmpeon/src/main/resources" charset="UTF-8" />
+    <file url="file://$PROJECT_DIR$/releng/llmpeon-feature/src/main/java" charset="UTF-8" />
+    <file url="file://$PROJECT_DIR$/releng/llmpeon-feature/src/main/resources" charset="UTF-8" />
+    <file url="file://$PROJECT_DIR$/releng/llmpeon-target/src/main/java" charset="UTF-8" />
+    <file url="file://$PROJECT_DIR$/releng/llmpeon-target/src/main/resources" charset="UTF-8" />
+    <file url="file://$PROJECT_DIR$/releng/llmpeon-update-site/src/main/java" charset="UTF-8" />
+    <file url="file://$PROJECT_DIR$/releng/llmpeon-update-site/src/main/resources" charset="UTF-8" />
+    <file url="file://$PROJECT_DIR$/src/main/java" charset="UTF-8" />
+    <file url="file://$PROJECT_DIR$/src/main/resources" charset="UTF-8" />
+  </component>
+</project>

--- a/.idea/git_toolbox_blame.xml
+++ b/.idea/git_toolbox_blame.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="GitToolBoxBlameSettings">
+    <option name="version" value="2" />
+  </component>
+</project>

--- a/.idea/jarRepositories.xml
+++ b/.idea/jarRepositories.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="RemoteRepositoriesConfiguration">
+    <remote-repository>
+      <option name="id" value="central" />
+      <option name="name" value="Central Repository" />
+      <option name="url" value="https://repo.maven.apache.org/maven2" />
+    </remote-repository>
+    <remote-repository>
+      <option name="id" value="central" />
+      <option name="name" value="Maven Central repository" />
+      <option name="url" value="https://repo1.maven.org/maven2" />
+    </remote-repository>
+    <remote-repository>
+      <option name="id" value="jboss.community" />
+      <option name="name" value="JBoss Community repository" />
+      <option name="url" value="https://repository.jboss.org/nexus/content/repositories/public/" />
+    </remote-repository>
+  </component>
+</project>

--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="ExternalStorageConfigurationManager" enabled="true" />
+  <component name="MavenProjectsManager">
+    <option name="originalFiles">
+      <list>
+        <option value="$PROJECT_DIR$/pom.xml" />
+      </list>
+    </option>
+  </component>
+  <component name="ProjectRootManager" version="2" languageLevel="JDK_X" default="true" project-jdk-name="ms-21" project-jdk-type="JavaSDK" />
+</project>

--- a/.idea/uiDesigner.xml
+++ b/.idea/uiDesigner.xml
@@ -1,0 +1,124 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="Palette2">
+    <group name="Swing">
+      <item class="com.intellij.uiDesigner.HSpacer" tooltip-text="Horizontal Spacer" icon="/com/intellij/uiDesigner/icons/hspacer.svg" removable="false" auto-create-binding="false" can-attach-label="false">
+        <default-constraints vsize-policy="1" hsize-policy="6" anchor="0" fill="1" />
+      </item>
+      <item class="com.intellij.uiDesigner.VSpacer" tooltip-text="Vertical Spacer" icon="/com/intellij/uiDesigner/icons/vspacer.svg" removable="false" auto-create-binding="false" can-attach-label="false">
+        <default-constraints vsize-policy="6" hsize-policy="1" anchor="0" fill="2" />
+      </item>
+      <item class="javax.swing.JPanel" icon="/com/intellij/uiDesigner/icons/panel.svg" removable="false" auto-create-binding="false" can-attach-label="false">
+        <default-constraints vsize-policy="3" hsize-policy="3" anchor="0" fill="3" />
+      </item>
+      <item class="javax.swing.JScrollPane" icon="/com/intellij/uiDesigner/icons/scrollPane.svg" removable="false" auto-create-binding="false" can-attach-label="true">
+        <default-constraints vsize-policy="7" hsize-policy="7" anchor="0" fill="3" />
+      </item>
+      <item class="javax.swing.JButton" icon="/com/intellij/uiDesigner/icons/button.svg" removable="false" auto-create-binding="true" can-attach-label="false">
+        <default-constraints vsize-policy="0" hsize-policy="3" anchor="0" fill="1" />
+        <initial-values>
+          <property name="text" value="Button" />
+        </initial-values>
+      </item>
+      <item class="javax.swing.JRadioButton" icon="/com/intellij/uiDesigner/icons/radioButton.svg" removable="false" auto-create-binding="true" can-attach-label="false">
+        <default-constraints vsize-policy="0" hsize-policy="3" anchor="8" fill="0" />
+        <initial-values>
+          <property name="text" value="RadioButton" />
+        </initial-values>
+      </item>
+      <item class="javax.swing.JCheckBox" icon="/com/intellij/uiDesigner/icons/checkBox.svg" removable="false" auto-create-binding="true" can-attach-label="false">
+        <default-constraints vsize-policy="0" hsize-policy="3" anchor="8" fill="0" />
+        <initial-values>
+          <property name="text" value="CheckBox" />
+        </initial-values>
+      </item>
+      <item class="javax.swing.JLabel" icon="/com/intellij/uiDesigner/icons/label.svg" removable="false" auto-create-binding="false" can-attach-label="false">
+        <default-constraints vsize-policy="0" hsize-policy="0" anchor="8" fill="0" />
+        <initial-values>
+          <property name="text" value="Label" />
+        </initial-values>
+      </item>
+      <item class="javax.swing.JTextField" icon="/com/intellij/uiDesigner/icons/textField.svg" removable="false" auto-create-binding="true" can-attach-label="true">
+        <default-constraints vsize-policy="0" hsize-policy="6" anchor="8" fill="1">
+          <preferred-size width="150" height="-1" />
+        </default-constraints>
+      </item>
+      <item class="javax.swing.JPasswordField" icon="/com/intellij/uiDesigner/icons/passwordField.svg" removable="false" auto-create-binding="true" can-attach-label="true">
+        <default-constraints vsize-policy="0" hsize-policy="6" anchor="8" fill="1">
+          <preferred-size width="150" height="-1" />
+        </default-constraints>
+      </item>
+      <item class="javax.swing.JFormattedTextField" icon="/com/intellij/uiDesigner/icons/formattedTextField.svg" removable="false" auto-create-binding="true" can-attach-label="true">
+        <default-constraints vsize-policy="0" hsize-policy="6" anchor="8" fill="1">
+          <preferred-size width="150" height="-1" />
+        </default-constraints>
+      </item>
+      <item class="javax.swing.JTextArea" icon="/com/intellij/uiDesigner/icons/textArea.svg" removable="false" auto-create-binding="true" can-attach-label="true">
+        <default-constraints vsize-policy="6" hsize-policy="6" anchor="0" fill="3">
+          <preferred-size width="150" height="50" />
+        </default-constraints>
+      </item>
+      <item class="javax.swing.JTextPane" icon="/com/intellij/uiDesigner/icons/textPane.svg" removable="false" auto-create-binding="true" can-attach-label="true">
+        <default-constraints vsize-policy="6" hsize-policy="6" anchor="0" fill="3">
+          <preferred-size width="150" height="50" />
+        </default-constraints>
+      </item>
+      <item class="javax.swing.JEditorPane" icon="/com/intellij/uiDesigner/icons/editorPane.svg" removable="false" auto-create-binding="true" can-attach-label="true">
+        <default-constraints vsize-policy="6" hsize-policy="6" anchor="0" fill="3">
+          <preferred-size width="150" height="50" />
+        </default-constraints>
+      </item>
+      <item class="javax.swing.JComboBox" icon="/com/intellij/uiDesigner/icons/comboBox.svg" removable="false" auto-create-binding="true" can-attach-label="true">
+        <default-constraints vsize-policy="0" hsize-policy="2" anchor="8" fill="1" />
+      </item>
+      <item class="javax.swing.JTable" icon="/com/intellij/uiDesigner/icons/table.svg" removable="false" auto-create-binding="true" can-attach-label="false">
+        <default-constraints vsize-policy="6" hsize-policy="6" anchor="0" fill="3">
+          <preferred-size width="150" height="50" />
+        </default-constraints>
+      </item>
+      <item class="javax.swing.JList" icon="/com/intellij/uiDesigner/icons/list.svg" removable="false" auto-create-binding="true" can-attach-label="false">
+        <default-constraints vsize-policy="6" hsize-policy="2" anchor="0" fill="3">
+          <preferred-size width="150" height="50" />
+        </default-constraints>
+      </item>
+      <item class="javax.swing.JTree" icon="/com/intellij/uiDesigner/icons/tree.svg" removable="false" auto-create-binding="true" can-attach-label="false">
+        <default-constraints vsize-policy="6" hsize-policy="6" anchor="0" fill="3">
+          <preferred-size width="150" height="50" />
+        </default-constraints>
+      </item>
+      <item class="javax.swing.JTabbedPane" icon="/com/intellij/uiDesigner/icons/tabbedPane.svg" removable="false" auto-create-binding="true" can-attach-label="false">
+        <default-constraints vsize-policy="3" hsize-policy="3" anchor="0" fill="3">
+          <preferred-size width="200" height="200" />
+        </default-constraints>
+      </item>
+      <item class="javax.swing.JSplitPane" icon="/com/intellij/uiDesigner/icons/splitPane.svg" removable="false" auto-create-binding="false" can-attach-label="false">
+        <default-constraints vsize-policy="3" hsize-policy="3" anchor="0" fill="3">
+          <preferred-size width="200" height="200" />
+        </default-constraints>
+      </item>
+      <item class="javax.swing.JSpinner" icon="/com/intellij/uiDesigner/icons/spinner.svg" removable="false" auto-create-binding="true" can-attach-label="true">
+        <default-constraints vsize-policy="0" hsize-policy="6" anchor="8" fill="1" />
+      </item>
+      <item class="javax.swing.JSlider" icon="/com/intellij/uiDesigner/icons/slider.svg" removable="false" auto-create-binding="true" can-attach-label="false">
+        <default-constraints vsize-policy="0" hsize-policy="6" anchor="8" fill="1" />
+      </item>
+      <item class="javax.swing.JSeparator" icon="/com/intellij/uiDesigner/icons/separator.svg" removable="false" auto-create-binding="false" can-attach-label="false">
+        <default-constraints vsize-policy="6" hsize-policy="6" anchor="0" fill="3" />
+      </item>
+      <item class="javax.swing.JProgressBar" icon="/com/intellij/uiDesigner/icons/progressbar.svg" removable="false" auto-create-binding="true" can-attach-label="false">
+        <default-constraints vsize-policy="0" hsize-policy="6" anchor="0" fill="1" />
+      </item>
+      <item class="javax.swing.JToolBar" icon="/com/intellij/uiDesigner/icons/toolbar.svg" removable="false" auto-create-binding="false" can-attach-label="false">
+        <default-constraints vsize-policy="0" hsize-policy="6" anchor="0" fill="1">
+          <preferred-size width="-1" height="20" />
+        </default-constraints>
+      </item>
+      <item class="javax.swing.JToolBar$Separator" icon="/com/intellij/uiDesigner/icons/toolbarSeparator.svg" removable="false" auto-create-binding="false" can-attach-label="false">
+        <default-constraints vsize-policy="0" hsize-policy="0" anchor="0" fill="1" />
+      </item>
+      <item class="javax.swing.JScrollBar" icon="/com/intellij/uiDesigner/icons/scrollbar.svg" removable="false" auto-create-binding="true" can-attach-label="false">
+        <default-constraints vsize-policy="6" hsize-policy="0" anchor="0" fill="2" />
+      </item>
+    </group>
+  </component>
+</project>

--- a/.idea/vcs.xml
+++ b/.idea/vcs.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="VcsDirectoryMappings">
+    <mapping directory="" vcs="Git" />
+  </component>
+</project>

--- a/org.sterl.llmpeon.core/src/main/java/org/sterl/llmpeon/AbstractChatService.java
+++ b/org.sterl.llmpeon.core/src/main/java/org/sterl/llmpeon/AbstractChatService.java
@@ -13,7 +13,7 @@ import org.sterl.llmpeon.ai.ConfiguredModel;
 import org.sterl.llmpeon.ai.LlmConfig;
 import org.sterl.llmpeon.shared.AiMonitor;
 import org.sterl.llmpeon.shared.StringUtil;
-import org.sterl.llmpeon.skill.Skill;
+import org.sterl.llmpeon.skill.SkillPromptFile;
 import org.sterl.llmpeon.skill.SkillService;
 import org.sterl.llmpeon.streaming.StreamingBridge;
 import org.sterl.llmpeon.template.TemplateContext;
@@ -168,7 +168,7 @@ public abstract class AbstractChatService {
     public int getTokenSize() { return tokenSize; }
     public int getTokenWindow() { return configuredModel.getTokenWindow(); }
     public TemplateContext getTemplateContext() { return templateContext; }
-    public List<Skill> getSkills() { return skillService.getSkills(); }
+    public List<SkillPromptFile> getSkills() { return skillService.getSkills(); }
 
     private List<ChatMessage> buildStaticMessages() {
         var messages = new ArrayList<ChatMessage>();

--- a/org.sterl.llmpeon.core/src/main/java/org/sterl/llmpeon/command/CommandPromptFile.java
+++ b/org.sterl.llmpeon.core/src/main/java/org/sterl/llmpeon/command/CommandPromptFile.java
@@ -4,9 +4,9 @@ import java.nio.file.Path;
 
 import org.sterl.llmpeon.shared.AbstractPromptFile;
 
-public class CommandRecord extends AbstractPromptFile {
+public class CommandPromptFile extends AbstractPromptFile {
 
-    public CommandRecord(String name, String description, Path promptFile) {
+    public CommandPromptFile(String name, String description, Path promptFile) {
         super(name, description, promptFile, true);
     }
 

--- a/org.sterl.llmpeon.core/src/main/java/org/sterl/llmpeon/command/CommandService.java
+++ b/org.sterl.llmpeon.core/src/main/java/org/sterl/llmpeon/command/CommandService.java
@@ -21,7 +21,7 @@ import lombok.NoArgsConstructor;
  * Loads user-defined slash commands from a configured directory.
  *
  * <p>Each {@code <name>.md} file directly inside the directory becomes one
- * {@link CommandRecord}. Unlike {@link org.sterl.llmpeon.skill.SkillService}, the
+ * {@link CommandPromptFile}. Unlike {@link org.sterl.llmpeon.skill.SkillService}, the
  * frontmatter is optional and only the {@code description} field is parsed.
  * Hidden files and files in subdirectories are ignored.</p>
  */
@@ -29,7 +29,7 @@ import lombok.NoArgsConstructor;
 public class CommandService {
 
     private volatile Path commandsDirectory;
-    private final Map<String, CommandRecord> commands = new ConcurrentHashMap<>();
+    private final Map<String, CommandPromptFile> commands = new ConcurrentHashMap<>();
     private volatile boolean enabled = true;
 
     public CommandService(Path commandsDirectory) throws IOException {
@@ -55,17 +55,17 @@ public class CommandService {
         commands.values().forEach(cmd -> cmd.setEnabled(enabled));
     }
 
-    public List<CommandRecord> getCommands() {
+    public List<CommandPromptFile> getCommands() {
         return enabled
                 ? commands.values().stream()
-                    .filter(CommandRecord::isEnabled)
+                    .filter(CommandPromptFile::isEnabled)
                     .sorted(Comparator.comparing(c -> c.name().toLowerCase(Locale.ROOT)))
                     .toList()
                 : List.of();
     }
 
     /** Returns all loaded commands regardless of global enabled state. */
-    public List<CommandRecord> getAllLoadedCommands() {
+    public List<CommandPromptFile> getAllLoadedCommands() {
         return commands.values().stream()
                 .sorted(Comparator.comparing(c -> c.name().toLowerCase(Locale.ROOT)))
                 .toList();
@@ -103,14 +103,14 @@ public class CommandService {
                 if (!Files.isRegularFile(file)) continue;
                 var fileName = file.getFileName().toString();
                 if (fileName.startsWith(".")) continue;
-                CommandRecord cmd = PromptYmlParser.parseCommand(file);
+                CommandPromptFile cmd = PromptYmlParser.parseCommand(file);
                 if (cmd != null) commands.put(cmd.name().toLowerCase(Locale.ROOT), cmd);
             }
         }
         return true;
     }
 
-    public Optional<CommandRecord> get(String name) {
+    public Optional<CommandPromptFile> get(String name) {
         if (name == null || name.isBlank()) return Optional.empty();
         return Optional.ofNullable(commands.get(name.toLowerCase(Locale.ROOT)));
     }
@@ -123,7 +123,7 @@ public class CommandService {
      * Returns all active command names
      */
     public String commandNames() {
-        return getCommands().stream().map(CommandRecord::name).collect(Collectors.joining(", "));
+        return getCommands().stream().map(CommandPromptFile::name).collect(Collectors.joining(", "));
     }
 
     public Path getCommandsDirectory() {

--- a/org.sterl.llmpeon.core/src/main/java/org/sterl/llmpeon/shared/PromptYmlParser.java
+++ b/org.sterl.llmpeon.core/src/main/java/org/sterl/llmpeon/shared/PromptYmlParser.java
@@ -7,12 +7,12 @@ import java.nio.file.Path;
 import java.util.LinkedHashMap;
 import java.util.Map;
 
-import org.sterl.llmpeon.command.CommandRecord;
-import org.sterl.llmpeon.skill.Skill;
+import org.sterl.llmpeon.command.CommandPromptFile;
+import org.sterl.llmpeon.skill.SkillPromptFile;
 
 public class PromptYmlParser {
 
-    public static Skill parseSkill(Path skillFile) throws IOException {
+    public static SkillPromptFile parseSkill(Path skillFile) throws IOException {
         if (!Files.isRegularFile(skillFile)) return null;
 
         String fileName = skillFile.getFileName().toString();
@@ -30,12 +30,12 @@ public class PromptYmlParser {
         String description = frontmatter.get("description");
 
         if (name != null && description != null) {
-            return new Skill(name, description, skillFile);
+            return new SkillPromptFile(name, description, skillFile);
         }
         return null;
     }
 
-    public static CommandRecord parseCommand(Path commandFile) throws IOException {
+    public static CommandPromptFile parseCommand(Path commandFile) throws IOException {
         if (!Files.isRegularFile(commandFile)) return null;
         var fileName = commandFile.getFileName().toString();
         if (!fileName.endsWith(".md")) return null;
@@ -46,7 +46,7 @@ public class PromptYmlParser {
         String name = frontmatter.getOrDefault("name", defaultName);
         String description = frontmatter.get("description");
 
-        return new CommandRecord(name, description, commandFile);
+        return new CommandPromptFile(name, description, commandFile);
     }
 
     static Map<String, String> parseFrontmatter(Path file) throws IOException {

--- a/org.sterl.llmpeon.core/src/main/java/org/sterl/llmpeon/skill/SkillPromptFile.java
+++ b/org.sterl.llmpeon.core/src/main/java/org/sterl/llmpeon/skill/SkillPromptFile.java
@@ -4,9 +4,9 @@ import java.nio.file.Path;
 
 import org.sterl.llmpeon.shared.AbstractPromptFile;
 
-public class Skill extends AbstractPromptFile {
+public class SkillPromptFile extends AbstractPromptFile {
 
-    public Skill(String name, String description, Path promptFile) {
+    public SkillPromptFile(String name, String description, Path promptFile) {
         super(name, description, promptFile, true);
     }
 

--- a/org.sterl.llmpeon.core/src/main/java/org/sterl/llmpeon/skill/SkillService.java
+++ b/org.sterl.llmpeon.core/src/main/java/org/sterl/llmpeon/skill/SkillService.java
@@ -23,7 +23,7 @@ import lombok.NoArgsConstructor;
 public class SkillService {
 
     private volatile Path skillsDirectory;
-    private final Map<String, Skill> skills = new ConcurrentHashMap<>();
+    private final Map<String, SkillPromptFile> skills = new ConcurrentHashMap<>();
     private volatile boolean enabled = true;
 
     public SkillService(Path skillsDirectory) throws IOException {
@@ -65,16 +65,16 @@ public class SkillService {
     }
 
     /** Returns loaded skills when enabled, empty list when disabled. */
-    public List<Skill> getSkills() {
-        return enabled 
+    public List<SkillPromptFile> getSkills() {
+        return enabled
                 ? skills.values().stream()
-                    .filter(Skill::isEnabled)
-                    .toList() 
+                    .filter(SkillPromptFile::isEnabled)
+                    .toList()
                 : List.of();
     }
 
     /** Returns all loaded skills regardless of global enabled state. */
-    public List<Skill> getAllLoadedSkills() {
+    public List<SkillPromptFile> getAllLoadedSkills() {
         return new LinkedList<>(skills.values());
     }
 
@@ -98,7 +98,7 @@ public class SkillService {
                     if (Files.isDirectory(entry)) {
                         var skillFile = detectSkillFile(entry);
                         if (skillFile != null && Files.isRegularFile(skillFile)) {
-                            Skill skill = PromptYmlParser.parseSkill(skillFile);
+                            SkillPromptFile skill = PromptYmlParser.parseSkill(skillFile);
                             if (skill != null) {
                                 skills.put(skill.getName().toLowerCase(Locale.ROOT), skill);
                             }
@@ -107,7 +107,7 @@ public class SkillService {
                         var fileName = entry.getFileName().toString();
                         if (fileName.startsWith(".")) continue;
                         if (fileName.endsWith(".md")) {
-                            Skill skill = PromptYmlParser.parseSkill(entry);
+                            SkillPromptFile skill = PromptYmlParser.parseSkill(entry);
                             if (skill != null) {
                                 skills.put(skill.getName().toLowerCase(Locale.ROOT), skill);
                             }
@@ -130,7 +130,7 @@ public class SkillService {
     /**
      * Return the skill -- also the disabled ones
      */
-    public Optional<Skill> get(String name) {
+    public Optional<SkillPromptFile> get(String name) {
         if (name == null || name.isBlank()) return Optional.empty();
         return Optional.ofNullable(skills.get(name.toLowerCase(Locale.ROOT)));
     }
@@ -143,6 +143,6 @@ public class SkillService {
      * Returns all active skill names
      */
     public String skillNames() {
-        return getSkills().stream().map(Skill::name).collect(Collectors.joining(", "));
+        return getSkills().stream().map(SkillPromptFile::name).collect(Collectors.joining(", "));
     }
 }

--- a/org.sterl.llmpeon.core/src/test/java/org/sterl/llmpeon/command/CommandServiceTest.java
+++ b/org.sterl.llmpeon.core/src/test/java/org/sterl/llmpeon/command/CommandServiceTest.java
@@ -173,7 +173,7 @@ class CommandServiceTest {
 
         // THEN
         assertThat(service.getCommands())
-                .extracting(CommandRecord::name)
+                .extracting(CommandPromptFile::name)
                 .containsExactly("Alpha", "beta", "zebra");
     }
 

--- a/org.sterl.llmpeon.core/src/test/java/org/sterl/llmpeon/skill/SkillServiceTest.java
+++ b/org.sterl.llmpeon.core/src/test/java/org/sterl/llmpeon/skill/SkillServiceTest.java
@@ -103,13 +103,13 @@ class SkillServiceTest {
         subject.setAllSkillsEnabled(false);
 
         // THEN
-        assertThat(allSkills).noneMatch(Skill::isEnabled);
+        assertThat(allSkills).noneMatch(SkillPromptFile::isEnabled);
 
         // WHEN
         subject.setAllSkillsEnabled(true);
 
         // THEN
-        assertThat(allSkills).allMatch(Skill::isEnabled);
+        assertThat(allSkills).allMatch(SkillPromptFile::isEnabled);
     }
 
     @Test

--- a/org.sterl.llmpeon/src/org/sterl/llmpeon/parts/widget/SlashMenuPopup.java
+++ b/org.sterl.llmpeon/src/org/sterl/llmpeon/parts/widget/SlashMenuPopup.java
@@ -17,7 +17,7 @@ import org.eclipse.swt.widgets.Shell;
 import org.eclipse.swt.widgets.Table;
 import org.eclipse.swt.widgets.TableColumn;
 import org.eclipse.swt.widgets.TableItem;
-import org.sterl.llmpeon.command.CommandRecord;
+import org.sterl.llmpeon.command.CommandPromptFile;
 
 /**
  * Lightweight popup that lists slash-commands matching the current prefix.
@@ -36,17 +36,17 @@ public class SlashMenuPopup {
     private static final int MAX_WIDTH = 520;
 
     private final Composite anchor;
-    private final Consumer<CommandRecord> onSelect;
+    private final Consumer<CommandPromptFile> onSelect;
     private final Listener anchorShellMoveListener;
     private final Shell anchorShell;
 
     private Shell popup;
     private Table table;
-    private List<CommandRecord> filtered = List.of();
-    private List<CommandRecord> source = List.of();
+    private List<CommandPromptFile> filtered = List.of();
+    private List<CommandPromptFile> source = List.of();
     private String currentPrefix = "";
 
-    public SlashMenuPopup(Composite anchor, Consumer<CommandRecord> onSelect) {
+    public SlashMenuPopup(Composite anchor, Consumer<CommandPromptFile> onSelect) {
         this.anchor = anchor;
         this.onSelect = onSelect;
         this.anchorShell = anchor.getShell();
@@ -77,7 +77,7 @@ public class SlashMenuPopup {
      * @param prefix       prefix already typed after the slash, may be empty
      * @param anchorScreen anchor position in display coordinates (typically the caret location)
      */
-    public void show(List<CommandRecord> commands, String prefix, Point anchorScreen) {
+    public void show(List<CommandPromptFile> commands, String prefix, Point anchorScreen) {
         this.source = commands == null ? List.of() : commands;
         this.currentPrefix = prefix == null ? "" : prefix;
         var matches = filter(this.source, this.currentPrefix);
@@ -162,7 +162,7 @@ public class SlashMenuPopup {
 
     private void rebuildItems() {
         table.removeAll();
-        for (CommandRecord cmd : filtered) {
+        for (CommandPromptFile cmd : filtered) {
             var item = new TableItem(table, SWT.NONE);
             item.setText(formatRow(cmd));
         }
@@ -196,14 +196,14 @@ public class SlashMenuPopup {
         popup.setBounds(bounds);
     }
 
-    private static String formatRow(CommandRecord cmd) {
+    private static String formatRow(CommandPromptFile cmd) {
         if (cmd.description() == null || cmd.description().isBlank()) {
             return "/" + cmd.name();
         }
         return "/" + cmd.name() + "  \u2014  " + cmd.description();
     }
 
-    private static List<CommandRecord> filter(List<CommandRecord> source, String prefix) {
+    private static List<CommandPromptFile> filter(List<CommandPromptFile> source, String prefix) {
         if (prefix == null || prefix.isEmpty()) return source;
         var lower = prefix.toLowerCase(Locale.ROOT);
         return source.stream()

--- a/org.sterl.llmpeon/src/org/sterl/llmpeon/parts/widget/StatusLineWidget.java
+++ b/org.sterl.llmpeon/src/org/sterl/llmpeon/parts/widget/StatusLineWidget.java
@@ -22,7 +22,7 @@ import org.eclipse.ui.PlatformUI;
 import org.sterl.llmpeon.parts.shared.EclipseUiUtil;
 import org.sterl.llmpeon.parts.shared.ImageUtil;
 import org.sterl.llmpeon.shared.StringUtil;
-import org.sterl.llmpeon.skill.Skill;
+import org.sterl.llmpeon.skill.SkillPromptFile;
 
 /**
  * Status bar below the action bar. Shows project pin, selected file, skills
@@ -41,7 +41,7 @@ public class StatusLineWidget extends Composite {
 
     private final Color colorWarning;
     private final Color colorError;
-    private Supplier<List<Skill>> skillsProvider;
+    private Supplier<List<SkillPromptFile>> skillsProvider;
     private Consumer<SkillMenuSelection> onSkillMenuChange;
 
     private final ISharedImages images = PlatformUI.getWorkbench().getSharedImages();
@@ -225,7 +225,7 @@ public class StatusLineWidget extends Composite {
     }
 
     /** Set the provider for loading skills and callback for menu changes. */
-    public void setSkillsMenuHandler(Supplier<List<Skill>> provider, Consumer<SkillMenuSelection> onChange) {
+    public void setSkillsMenuHandler(Supplier<List<SkillPromptFile>> provider, Consumer<SkillMenuSelection> onChange) {
         this.skillsProvider = provider;
         this.onSkillMenuChange = onChange;
     }
@@ -233,7 +233,7 @@ public class StatusLineWidget extends Composite {
     private void showSkillsMenu() {
         if (skillsProvider == null) return;
 
-        List<Skill> skills = skillsProvider.get();
+        List<SkillPromptFile> skills = skillsProvider.get();
         if (skills.isEmpty()) return;
 
         Menu menu = new Menu(btnSkills);
@@ -241,7 +241,7 @@ public class StatusLineWidget extends Composite {
         // "All" option at the top
         MenuItem allItem = new MenuItem(menu, SWT.CHECK);
         allItem.setText("All Skills");
-        boolean allEnabled = skills.stream().allMatch(Skill::isEnabled);
+        boolean allEnabled = skills.stream().allMatch(SkillPromptFile::isEnabled);
         allItem.setSelection(allEnabled);
         allItem.addListener(SWT.Selection, e -> {
             boolean enable = allItem.getSelection();
@@ -253,7 +253,7 @@ public class StatusLineWidget extends Composite {
         new MenuItem(menu, SWT.SEPARATOR);
 
         // Individual skill items
-        for (Skill skill : skills) {
+        for (SkillPromptFile skill : skills) {
             MenuItem item = new MenuItem(menu, SWT.CHECK);
             item.setText(skill.name());
             item.setSelection(skill.isEnabled());

--- a/org.sterl.llmpeon/src/org/sterl/llmpeon/parts/widget/UserInputWidget.java
+++ b/org.sterl.llmpeon/src/org/sterl/llmpeon/parts/widget/UserInputWidget.java
@@ -14,7 +14,7 @@ import org.eclipse.swt.layout.GridLayout;
 import org.eclipse.swt.widgets.Button;
 import org.eclipse.swt.widgets.Composite;
 import org.eclipse.swt.widgets.Control;
-import org.sterl.llmpeon.command.CommandRecord;
+import org.sterl.llmpeon.command.CommandPromptFile;
 import org.sterl.llmpeon.parts.shared.ImageUtil;
 import org.sterl.llmpeon.parts.shared.SwtUtil;
 
@@ -42,7 +42,7 @@ public class UserInputWidget extends Composite {
     private final Color colorRecording;
 
     private SlashMenuPopup slashPopup;
-    private Supplier<List<CommandRecord>> commandSupplier;
+    private Supplier<List<CommandPromptFile>> commandSupplier;
 
     public UserInputWidget(Composite parent, int style, Runnable onSend, Runnable onStop, Runnable onMicClick) {
         super(parent, style);
@@ -233,7 +233,7 @@ public class UserInputWidget extends Composite {
      * Enables the slash-command popup. {@code commandSupplier} returns the currently loaded
      * commands. Pass {@code null} to disable the popup.
      */
-    public void enableSlashCommands(Supplier<List<CommandRecord>> commandSupplier) {
+    public void enableSlashCommands(Supplier<List<CommandPromptFile>> commandSupplier) {
         this.commandSupplier = commandSupplier;
         if (commandSupplier == null) {
             disposeSlashPopup();
@@ -282,7 +282,7 @@ public class UserInputWidget extends Composite {
         return sb.toString();
     }
 
-    private void applyCommandSelection(CommandRecord cmd) {
+    private void applyCommandSelection(CommandPromptFile cmd) {
         var current = textInput.getText();
         var afterToken = "";
         if (current != null && current.startsWith("/")) {


### PR DESCRIPTION
Thank you very much for the AbstractPromptFile abstraction. I've proceeded with refactoring work based on it.
- Renamed Skill.java to SkillPromptFile.java for clarity
- Renamed CommandRecord.java to CommandPromptFile.java for consistency
- Updated all references across the codebase (18 files)
- Updated imports, return types, generics, and method references
- All 111 tests passing