### PR TITLE
Fix file editing for line endings 

### DIFF
--- a/org.sterl.llmpeon.core/src/main/java/org/sterl/llmpeon/shared/FileUtils.java
+++ b/org.sterl.llmpeon.core/src/main/java/org/sterl/llmpeon/shared/FileUtils.java
@@ -57,25 +57,73 @@ public class FileUtils {
      * Throws {@link IllegalArgumentException} if there are zero or more than one match.
      */
     public static String applyEdit(String filePath, String content, String oldStr, String newStr) {
+        var edit = findEdit(filePath, content, oldStr, newStr);
+        return content.replace(edit.oldStr(), edit.newStr());
+    }
+
+    private static Edit findEdit(String filePath, String content, String oldStr, String newStr) {
+        int count = countMatches(content, oldStr);
+        String lineEnding = dominantLineEnding(content);
+        if (count == 1) return new Edit(oldStr, normalizeLineEndings(newStr, lineEnding));
+
+        if (count == 0) {
+            String normalizedOld = normalizeLineEndings(oldStr, lineEnding);
+            if (!oldStr.equals(normalizedOld)) {
+                int normalizedCount = countMatches(content, normalizedOld);
+                if (normalizedCount == 1) {
+                    return new Edit(normalizedOld, normalizeLineEndings(newStr, lineEnding));
+                }
+                if (normalizedCount > 1) {
+                    throw tooManyMatches(filePath, normalizedCount);
+                }
+            }
+            throw notFound(filePath, oldStr, hasLineEndingMismatch(content, oldStr));
+        }
+
+        throw tooManyMatches(filePath, count);
+    }
+
+    private static int countMatches(String content, String oldStr) {
         int count = 0;
         int idx = 0;
         while ((idx = content.indexOf(oldStr, idx)) != -1) {
             count++;
             idx += oldStr.length();
         }
-        if (count == 0) {
-            throw new IllegalArgumentException(
-                    "old_string: '" 
-                            + oldStr
-                            + "' not found in " + filePath + ". Read the file first to verify the exact content.");
-        }
-        if (count > 1) {
-            throw new IllegalArgumentException(
-                    "old_string found " + count + " times in " + filePath
-                            + ". Include more surrounding context to make the match unique.");
-        }
-        return content.replace(oldStr, newStr);
+        return count;
     }
+
+    private static String dominantLineEnding(String content) {
+        return content.contains("\r\n") ? "\r\n" : "\n";
+    }
+
+    private static String normalizeLineEndings(String value, String lineEnding) {
+        return value.replace("\r\n", "\n").replace('\r', '\n').replace("\n", lineEnding);
+    }
+
+    private static boolean hasLineEndingMismatch(String content, String oldStr) {
+        return content.contains("\r\n") && oldStr.contains("\n") && !oldStr.contains("\r\n")
+                || !content.contains("\r\n") && oldStr.contains("\r\n");
+    }
+
+    private static IllegalArgumentException notFound(String filePath, String oldStr, boolean lineEndingMismatch) {
+        String suffix = lineEndingMismatch
+                ? " The file and old_string use different line endings; line endings were normalized but the text still did not match."
+                : "";
+        return new IllegalArgumentException(
+                "old_string: '" 
+                        + oldStr
+                        + "' not found in " + filePath + ". Read the file first to verify the exact content."
+                        + suffix);
+    }
+
+    private static IllegalArgumentException tooManyMatches(String filePath, int count) {
+        return new IllegalArgumentException(
+                "old_string found " + count + " times in " + filePath
+                        + ". Include more surrounding context to make the match unique.");
+    }
+
+    private record Edit(String oldStr, String newStr) {}
 
     public static void writeString(Path f, String content) {
         try {

--- a/org.sterl.llmpeon.core/src/test/java/org/sterl/llmpeon/shared/FileUtilsTest.java
+++ b/org.sterl.llmpeon.core/src/test/java/org/sterl/llmpeon/shared/FileUtilsTest.java
@@ -2,6 +2,7 @@ package org.sterl.llmpeon.shared;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.io.IOException;
 import java.nio.file.Files;
@@ -40,5 +41,56 @@ class FileUtilsTest {
         Path file = tempDir.resolve("new.txt");
         FileUtils.writeString(file, "hello");
         assertEquals("hello", Files.readString(file));
+    }
+
+    @Test
+    void applyEdit_lfFileWithLfOldString() {
+        var result = FileUtils.applyEdit("test.txt", "one\ntwo\nthree", "two\nthree", "2\n3");
+
+        assertEquals("one\n2\n3", result);
+    }
+
+    @Test
+    void applyEdit_crlfFileWithCrlfOldString() {
+        var result = FileUtils.applyEdit("test.txt", "one\r\ntwo\r\nthree", "two\r\nthree", "2\r\n3");
+
+        assertEquals("one\r\n2\r\n3", result);
+    }
+
+    @Test
+    void applyEdit_crlfFileWithCrlfOldStringNormalizesLfNewString() {
+        var result = FileUtils.applyEdit("test.txt", "one\r\ntwo\r\nthree", "two\r\nthree", "2\n3");
+
+        assertEquals("one\r\n2\r\n3", result);
+    }
+
+    @Test
+    void applyEdit_crlfFileWithLfOldStringKeepsCrlf() {
+        var result = FileUtils.applyEdit("test.txt", "one\r\ntwo\r\nthree", "two\nthree", "2\n3");
+
+        assertEquals("one\r\n2\r\n3", result);
+    }
+
+    @Test
+    void applyEdit_lfFileWithCrlfOldStringKeepsLf() {
+        var result = FileUtils.applyEdit("test.txt", "one\ntwo\nthree", "two\r\nthree", "2\r\n3");
+
+        assertEquals("one\n2\n3", result);
+    }
+
+    @Test
+    void applyEdit_duplicateAfterLineEndingNormalizationFails() {
+        var error = assertThrows(IllegalArgumentException.class, () ->
+                FileUtils.applyEdit("test.txt", "one\r\ntwo\r\none\r\ntwo", "one\ntwo", "1\n2"));
+
+        assertThat(error.getMessage()).contains("old_string found 2 times");
+    }
+
+    @Test
+    void applyEdit_missingOldStringStillFails() {
+        var error = assertThrows(IllegalArgumentException.class, () ->
+                FileUtils.applyEdit("test.txt", "one\r\ntwo\r\nthree", "two\nmissing", "2\n3"));
+
+        assertThat(error.getMessage()).contains("old_string: 'two\nmissing' not found");
     }
 }


### PR DESCRIPTION
## Summary

fix: issue - https://github.com/sterlp/eclipse-peon-ai/issues/57

This PR makes file editing more robust in two cases:

  - Handles CRLF/LF mismatches when using exact `oldString` replacements.
  - Adds line-range edit tools for multi-line code changes, avoiding fragile long exact-string matching.

  ## Changes

  - Made `FileUtils.applyEdit()` line-ending aware while preserving the target file’s existing CRLF/LF style.
  - Added:
    - `replaceWorkspaceLines(filePath, startLine, endLine, newContent)`
    - `replaceDiskLines(filePath, startLine, endLine, newContent)`
  - Updated line replacement logic to preserve existing file line endings.
  - Updated the developer prompt to prefer line-range edits for multi-line code changes.
  - Added/updated tests for CRLF/LF handling and line-range edits.