### PR TITLE
feat: add dragged file paths to prompts

### DIFF
--- a/org.sterl.llmpeon.test/src/org/sterl/llmpeon/parts/widget/FileDropSupportTest.java
+++ b/org.sterl.llmpeon.test/src/org/sterl/llmpeon/parts/widget/FileDropSupportTest.java
@@ -6,35 +6,35 @@ import java.util.List;
 
 import org.junit.Test;
 
-public class TextInputWidgetTest {
+public class FileDropSupportTest {
 
     @Test
     public void formatsSingleDroppedFilePath() {
         assertEquals("'/Users/user/project/file.txt'",
-                TextInputWidget.formatDroppedFilePaths(List.of("/Users/user/project/file.txt")));
+                FileDropSupport.formatDroppedFilePaths(List.of("/Users/user/project/file.txt")));
     }
 
     @Test
     public void formatsMultipleDroppedFilePathsOnSeparateLines() {
         assertEquals("'/tmp/a.txt'\n'/tmp/b.txt'",
-                TextInputWidget.formatDroppedFilePaths(List.of("/tmp/a.txt", "/tmp/b.txt")));
+                FileDropSupport.formatDroppedFilePaths(List.of("/tmp/a.txt", "/tmp/b.txt")));
     }
 
     @Test
     public void skipsBlankDroppedFilePaths() {
         assertEquals("'/tmp/a.txt'",
-                TextInputWidget.formatDroppedFilePaths(List.of("", "  ", "/tmp/a.txt")));
+                FileDropSupport.formatDroppedFilePaths(List.of("", "  ", "/tmp/a.txt")));
     }
 
     @Test
     public void escapesSingleQuotesInDroppedFilePaths() {
         assertEquals("'/tmp/user\\'s file.txt'",
-                TextInputWidget.formatDroppedFilePaths(List.of("/tmp/user's file.txt")));
+                FileDropSupport.formatDroppedFilePaths(List.of("/tmp/user's file.txt")));
     }
 
     @Test
     public void readsOsFileTransferPaths() {
         assertEquals(List.of("/tmp/a.txt", "/tmp/b.txt"),
-                TextInputWidget.pathsFromDropData(new String[]{ "/tmp/a.txt", "/tmp/b.txt" }));
+                FileDropSupport.pathsFromDropData(new String[]{ "/tmp/a.txt", "/tmp/b.txt" }));
     }
 }

--- a/org.sterl.llmpeon.test/src/org/sterl/llmpeon/parts/widget/TextInputWidgetTest.java
+++ b/org.sterl.llmpeon.test/src/org/sterl/llmpeon/parts/widget/TextInputWidgetTest.java
@@ -1,0 +1,40 @@
+package org.sterl.llmpeon.parts.widget;
+
+import static org.junit.Assert.assertEquals;
+
+import java.util.List;
+
+import org.junit.Test;
+
+public class TextInputWidgetTest {
+
+    @Test
+    public void formatsSingleDroppedFilePath() {
+        assertEquals("'/Users/user/project/file.txt'",
+                TextInputWidget.formatDroppedFilePaths(List.of("/Users/user/project/file.txt")));
+    }
+
+    @Test
+    public void formatsMultipleDroppedFilePathsOnSeparateLines() {
+        assertEquals("'/tmp/a.txt'\n'/tmp/b.txt'",
+                TextInputWidget.formatDroppedFilePaths(List.of("/tmp/a.txt", "/tmp/b.txt")));
+    }
+
+    @Test
+    public void skipsBlankDroppedFilePaths() {
+        assertEquals("'/tmp/a.txt'",
+                TextInputWidget.formatDroppedFilePaths(List.of("", "  ", "/tmp/a.txt")));
+    }
+
+    @Test
+    public void escapesSingleQuotesInDroppedFilePaths() {
+        assertEquals("'/tmp/user\\'s file.txt'",
+                TextInputWidget.formatDroppedFilePaths(List.of("/tmp/user's file.txt")));
+    }
+
+    @Test
+    public void readsOsFileTransferPaths() {
+        assertEquals(List.of("/tmp/a.txt", "/tmp/b.txt"),
+                TextInputWidget.pathsFromDropData(new String[]{ "/tmp/a.txt", "/tmp/b.txt" }));
+    }
+}

--- a/org.sterl.llmpeon/src/org/sterl/llmpeon/parts/widget/FileDropSupport.java
+++ b/org.sterl.llmpeon/src/org/sterl/llmpeon/parts/widget/FileDropSupport.java
@@ -1,0 +1,143 @@
+package org.sterl.llmpeon.parts.widget;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.eclipse.core.resources.IResource;
+import org.eclipse.core.runtime.IAdaptable;
+import org.eclipse.jface.util.LocalSelectionTransfer;
+import org.eclipse.jface.viewers.ISelection;
+import org.eclipse.jface.viewers.IStructuredSelection;
+import org.eclipse.jdt.core.IJavaElement;
+import org.eclipse.swt.dnd.DND;
+import org.eclipse.swt.dnd.DropTarget;
+import org.eclipse.swt.dnd.DropTargetAdapter;
+import org.eclipse.swt.dnd.DropTargetEvent;
+import org.eclipse.swt.dnd.FileTransfer;
+import org.eclipse.swt.dnd.Transfer;
+import org.eclipse.swt.graphics.Point;
+import org.eclipse.swt.widgets.Control;
+import org.eclipse.ui.part.ResourceTransfer;
+import org.eclipse.swt.custom.StyledText;
+import org.sterl.llmpeon.parts.shared.JdtUtil;
+
+final class FileDropSupport {
+
+    private FileDropSupport() {
+    }
+
+    static void install(Control dropControl, StyledText targetText) {
+        var dropTarget = new DropTarget(dropControl, DND.DROP_COPY);
+        dropControl.addDisposeListener(e -> {
+            if (!dropTarget.isDisposed()) dropTarget.dispose();
+        });
+        dropTarget.setTransfer(new Transfer[]{
+                ResourceTransfer.getInstance(),
+                LocalSelectionTransfer.getTransfer(),
+                FileTransfer.getInstance()
+        });
+        dropTarget.addDropListener(new DropTargetAdapter() {
+            @Override
+            public void dragEnter(DropTargetEvent event) {
+                acceptCopy(event);
+            }
+
+            @Override
+            public void dragOperationChanged(DropTargetEvent event) {
+                acceptCopy(event);
+            }
+
+            @Override
+            public void dragOver(DropTargetEvent event) {
+                acceptCopy(event);
+            }
+
+            @Override
+            public void dropAccept(DropTargetEvent event) {
+                acceptCopy(event);
+            }
+
+            @Override
+            public void drop(DropTargetEvent event) {
+                String text = formatDroppedFilePaths(pathsFromDropData(event.data));
+                if (text.isEmpty()) return;
+                insertAtSelection(targetText, text);
+                targetText.setFocus();
+            }
+        });
+    }
+
+    private static void acceptCopy(DropTargetEvent event) {
+        if (event.detail == DND.DROP_DEFAULT || event.detail == DND.DROP_NONE) {
+            event.detail = DND.DROP_COPY;
+        }
+    }
+
+    private static void insertAtSelection(StyledText targetText, String text) {
+        Point selection = targetText.getSelection();
+        targetText.replaceTextRange(selection.x, selection.y - selection.x, text);
+        targetText.setSelection(selection.x + text.length());
+    }
+
+    static String formatDroppedFilePaths(List<String> paths) {
+        if (paths == null || paths.isEmpty()) return "";
+
+        var result = new StringBuilder();
+        for (String path : paths) {
+            if (path == null || path.isBlank()) continue;
+            if (result.length() > 0) result.append('\n');
+            result.append('\'').append(path.replace("'", "\\'")).append('\'');
+        }
+        return result.toString();
+    }
+
+    static List<String> pathsFromDropData(Object data) {
+        var paths = new ArrayList<String>();
+        addDropPaths(paths, data);
+        if (paths.isEmpty()) {
+            addDropPaths(paths, LocalSelectionTransfer.getTransfer().getSelection());
+        }
+        return paths;
+    }
+
+    private static void addDropPaths(List<String> paths, Object data) {
+        if (data == null) return;
+        if (data instanceof String[] values) {
+            for (String value : values) addPath(paths, value);
+        } else if (data instanceof IResource[] resources) {
+            for (IResource resource : resources) addResourcePath(paths, resource);
+        } else if (data instanceof IStructuredSelection selection) {
+            for (Object element : selection) addElementPath(paths, element);
+        } else if (data instanceof ISelection) {
+            return;
+        } else if (data instanceof Object[] values) {
+            for (Object value : values) addElementPath(paths, value);
+        } else {
+            addElementPath(paths, data);
+        }
+    }
+
+    private static void addElementPath(List<String> paths, Object element) {
+        if (element instanceof IResource resource) {
+            addResourcePath(paths, resource);
+        } else if (element instanceof IJavaElement javaElement) {
+            addResourcePath(paths, javaElement.getResource());
+        } else if (element instanceof IAdaptable adaptable) {
+            var resource = adaptable.getAdapter(IResource.class);
+            if (resource != null) {
+                addResourcePath(paths, resource);
+                return;
+            }
+            var javaElement = adaptable.getAdapter(IJavaElement.class);
+            if (javaElement != null) addResourcePath(paths, javaElement.getResource());
+        }
+    }
+
+    private static void addResourcePath(List<String> paths, IResource resource) {
+        addPath(paths, JdtUtil.diskPathOf(resource));
+    }
+
+    private static void addPath(List<String> paths, String path) {
+        if (path != null && !path.isBlank()) paths.add(path);
+    }
+}

--- a/org.sterl.llmpeon/src/org/sterl/llmpeon/parts/widget/TextInputWidget.java
+++ b/org.sterl.llmpeon/src/org/sterl/llmpeon/parts/widget/TextInputWidget.java
@@ -1,8 +1,23 @@
 package org.sterl.llmpeon.parts.widget;
 
+import java.util.ArrayList;
+import java.util.List;
+
+import org.eclipse.core.resources.IResource;
+import org.eclipse.core.runtime.IAdaptable;
+import org.eclipse.jface.util.LocalSelectionTransfer;
+import org.eclipse.jface.viewers.ISelection;
+import org.eclipse.jface.viewers.IStructuredSelection;
+import org.eclipse.jdt.core.IJavaElement;
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.custom.StyledText;
 import org.eclipse.swt.custom.VerifyKeyListener;
+import org.eclipse.swt.dnd.DND;
+import org.eclipse.swt.dnd.DropTarget;
+import org.eclipse.swt.dnd.DropTargetAdapter;
+import org.eclipse.swt.dnd.DropTargetEvent;
+import org.eclipse.swt.dnd.FileTransfer;
+import org.eclipse.swt.dnd.Transfer;
 import org.eclipse.swt.events.KeyListener;
 import org.eclipse.swt.events.ModifyListener;
 import org.eclipse.swt.graphics.Color;
@@ -10,6 +25,9 @@ import org.eclipse.swt.graphics.Point;
 import org.eclipse.swt.layout.GridData;
 import org.eclipse.swt.layout.GridLayout;
 import org.eclipse.swt.widgets.Composite;
+import org.eclipse.swt.widgets.Control;
+import org.eclipse.ui.part.ResourceTransfer;
+import org.sterl.llmpeon.parts.shared.JdtUtil;
 
 /**
  * Reusable auto-growing StyledText widget. The text area grows from a minimum of
@@ -35,6 +53,123 @@ public class TextInputWidget extends Composite {
         styledText = new StyledText(this, SWT.MULTI | SWT.WRAP);
         styledText.setLayoutData(new GridData(SWT.FILL, SWT.FILL, true, true));
         styledText.addModifyListener(e -> refreshHeight());
+        enableFilePathDrop(this);
+        enableFilePathDrop(styledText);
+    }
+
+    private void enableFilePathDrop(Control control) {
+        var dropTarget = new DropTarget(control, DND.DROP_COPY);
+        control.addDisposeListener(e -> {
+            if (!dropTarget.isDisposed()) dropTarget.dispose();
+        });
+        dropTarget.setTransfer(new Transfer[]{
+                ResourceTransfer.getInstance(),
+                LocalSelectionTransfer.getTransfer(),
+                FileTransfer.getInstance()
+        });
+        dropTarget.addDropListener(new DropTargetAdapter() {
+            @Override
+            public void dragEnter(DropTargetEvent event) {
+                acceptCopy(event);
+            }
+
+            @Override
+            public void dragOperationChanged(DropTargetEvent event) {
+                acceptCopy(event);
+            }
+
+            @Override
+            public void dragOver(DropTargetEvent event) {
+                acceptCopy(event);
+            }
+
+            @Override
+            public void dropAccept(DropTargetEvent event) {
+                acceptCopy(event);
+            }
+
+            @Override
+            public void drop(DropTargetEvent event) {
+                String text = formatDroppedFilePaths(pathsFromDropData(event.data));
+                if (text.isEmpty()) return;
+                insertAtSelection(text);
+                styledText.setFocus();
+            }
+        });
+    }
+
+    private static void acceptCopy(DropTargetEvent event) {
+        if (event.detail == DND.DROP_DEFAULT || event.detail == DND.DROP_NONE) {
+            event.detail = DND.DROP_COPY;
+        }
+    }
+
+    private void insertAtSelection(String text) {
+        Point selection = styledText.getSelection();
+        styledText.replaceTextRange(selection.x, selection.y - selection.x, text);
+        styledText.setSelection(selection.x + text.length());
+    }
+
+    static String formatDroppedFilePaths(List<String> paths) {
+        if (paths == null || paths.isEmpty()) return "";
+
+        var result = new StringBuilder();
+        for (String path : paths) {
+            if (path == null || path.isBlank()) continue;
+            if (result.length() > 0) result.append('\n');
+            result.append('\'').append(path.replace("'", "\\'")).append('\'');
+        }
+        return result.toString();
+    }
+
+    static List<String> pathsFromDropData(Object data) {
+        var paths = new ArrayList<String>();
+        addDropPaths(paths, data);
+        if (paths.isEmpty()) {
+            addDropPaths(paths, LocalSelectionTransfer.getTransfer().getSelection());
+        }
+        return paths;
+    }
+
+    private static void addDropPaths(List<String> paths, Object data) {
+        if (data == null) return;
+        if (data instanceof String[] values) {
+            for (String value : values) addPath(paths, value);
+        } else if (data instanceof IResource[] resources) {
+            for (IResource resource : resources) addResourcePath(paths, resource);
+        } else if (data instanceof IStructuredSelection selection) {
+            for (Object element : selection) addElementPath(paths, element);
+        } else if (data instanceof ISelection) {
+            return;
+        } else if (data instanceof Object[] values) {
+            for (Object value : values) addElementPath(paths, value);
+        } else {
+            addElementPath(paths, data);
+        }
+    }
+
+    private static void addElementPath(List<String> paths, Object element) {
+        if (element instanceof IResource resource) {
+            addResourcePath(paths, resource);
+        } else if (element instanceof IJavaElement javaElement) {
+            addResourcePath(paths, javaElement.getResource());
+        } else if (element instanceof IAdaptable adaptable) {
+            var resource = adaptable.getAdapter(IResource.class);
+            if (resource != null) {
+                addResourcePath(paths, resource);
+                return;
+            }
+            var javaElement = adaptable.getAdapter(IJavaElement.class);
+            if (javaElement != null) addResourcePath(paths, javaElement.getResource());
+        }
+    }
+
+    private static void addResourcePath(List<String> paths, IResource resource) {
+        addPath(paths, JdtUtil.diskPathOf(resource));
+    }
+
+    private static void addPath(List<String> paths, String path) {
+        if (path != null && !path.isBlank()) paths.add(path);
     }
 
     private void refreshHeight() {

--- a/org.sterl.llmpeon/src/org/sterl/llmpeon/parts/widget/TextInputWidget.java
+++ b/org.sterl.llmpeon/src/org/sterl/llmpeon/parts/widget/TextInputWidget.java
@@ -1,23 +1,8 @@
 package org.sterl.llmpeon.parts.widget;
 
-import java.util.ArrayList;
-import java.util.List;
-
-import org.eclipse.core.resources.IResource;
-import org.eclipse.core.runtime.IAdaptable;
-import org.eclipse.jface.util.LocalSelectionTransfer;
-import org.eclipse.jface.viewers.ISelection;
-import org.eclipse.jface.viewers.IStructuredSelection;
-import org.eclipse.jdt.core.IJavaElement;
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.custom.StyledText;
 import org.eclipse.swt.custom.VerifyKeyListener;
-import org.eclipse.swt.dnd.DND;
-import org.eclipse.swt.dnd.DropTarget;
-import org.eclipse.swt.dnd.DropTargetAdapter;
-import org.eclipse.swt.dnd.DropTargetEvent;
-import org.eclipse.swt.dnd.FileTransfer;
-import org.eclipse.swt.dnd.Transfer;
 import org.eclipse.swt.events.KeyListener;
 import org.eclipse.swt.events.ModifyListener;
 import org.eclipse.swt.graphics.Color;
@@ -25,9 +10,6 @@ import org.eclipse.swt.graphics.Point;
 import org.eclipse.swt.layout.GridData;
 import org.eclipse.swt.layout.GridLayout;
 import org.eclipse.swt.widgets.Composite;
-import org.eclipse.swt.widgets.Control;
-import org.eclipse.ui.part.ResourceTransfer;
-import org.sterl.llmpeon.parts.shared.JdtUtil;
 
 /**
  * Reusable auto-growing StyledText widget. The text area grows from a minimum of
@@ -53,123 +35,8 @@ public class TextInputWidget extends Composite {
         styledText = new StyledText(this, SWT.MULTI | SWT.WRAP);
         styledText.setLayoutData(new GridData(SWT.FILL, SWT.FILL, true, true));
         styledText.addModifyListener(e -> refreshHeight());
-        enableFilePathDrop(this);
-        enableFilePathDrop(styledText);
-    }
-
-    private void enableFilePathDrop(Control control) {
-        var dropTarget = new DropTarget(control, DND.DROP_COPY);
-        control.addDisposeListener(e -> {
-            if (!dropTarget.isDisposed()) dropTarget.dispose();
-        });
-        dropTarget.setTransfer(new Transfer[]{
-                ResourceTransfer.getInstance(),
-                LocalSelectionTransfer.getTransfer(),
-                FileTransfer.getInstance()
-        });
-        dropTarget.addDropListener(new DropTargetAdapter() {
-            @Override
-            public void dragEnter(DropTargetEvent event) {
-                acceptCopy(event);
-            }
-
-            @Override
-            public void dragOperationChanged(DropTargetEvent event) {
-                acceptCopy(event);
-            }
-
-            @Override
-            public void dragOver(DropTargetEvent event) {
-                acceptCopy(event);
-            }
-
-            @Override
-            public void dropAccept(DropTargetEvent event) {
-                acceptCopy(event);
-            }
-
-            @Override
-            public void drop(DropTargetEvent event) {
-                String text = formatDroppedFilePaths(pathsFromDropData(event.data));
-                if (text.isEmpty()) return;
-                insertAtSelection(text);
-                styledText.setFocus();
-            }
-        });
-    }
-
-    private static void acceptCopy(DropTargetEvent event) {
-        if (event.detail == DND.DROP_DEFAULT || event.detail == DND.DROP_NONE) {
-            event.detail = DND.DROP_COPY;
-        }
-    }
-
-    private void insertAtSelection(String text) {
-        Point selection = styledText.getSelection();
-        styledText.replaceTextRange(selection.x, selection.y - selection.x, text);
-        styledText.setSelection(selection.x + text.length());
-    }
-
-    static String formatDroppedFilePaths(List<String> paths) {
-        if (paths == null || paths.isEmpty()) return "";
-
-        var result = new StringBuilder();
-        for (String path : paths) {
-            if (path == null || path.isBlank()) continue;
-            if (result.length() > 0) result.append('\n');
-            result.append('\'').append(path.replace("'", "\\'")).append('\'');
-        }
-        return result.toString();
-    }
-
-    static List<String> pathsFromDropData(Object data) {
-        var paths = new ArrayList<String>();
-        addDropPaths(paths, data);
-        if (paths.isEmpty()) {
-            addDropPaths(paths, LocalSelectionTransfer.getTransfer().getSelection());
-        }
-        return paths;
-    }
-
-    private static void addDropPaths(List<String> paths, Object data) {
-        if (data == null) return;
-        if (data instanceof String[] values) {
-            for (String value : values) addPath(paths, value);
-        } else if (data instanceof IResource[] resources) {
-            for (IResource resource : resources) addResourcePath(paths, resource);
-        } else if (data instanceof IStructuredSelection selection) {
-            for (Object element : selection) addElementPath(paths, element);
-        } else if (data instanceof ISelection) {
-            return;
-        } else if (data instanceof Object[] values) {
-            for (Object value : values) addElementPath(paths, value);
-        } else {
-            addElementPath(paths, data);
-        }
-    }
-
-    private static void addElementPath(List<String> paths, Object element) {
-        if (element instanceof IResource resource) {
-            addResourcePath(paths, resource);
-        } else if (element instanceof IJavaElement javaElement) {
-            addResourcePath(paths, javaElement.getResource());
-        } else if (element instanceof IAdaptable adaptable) {
-            var resource = adaptable.getAdapter(IResource.class);
-            if (resource != null) {
-                addResourcePath(paths, resource);
-                return;
-            }
-            var javaElement = adaptable.getAdapter(IJavaElement.class);
-            if (javaElement != null) addResourcePath(paths, javaElement.getResource());
-        }
-    }
-
-    private static void addResourcePath(List<String> paths, IResource resource) {
-        addPath(paths, JdtUtil.diskPathOf(resource));
-    }
-
-    private static void addPath(List<String> paths, String path) {
-        if (path != null && !path.isBlank()) paths.add(path);
+        FileDropSupport.install(this, styledText);
+        FileDropSupport.install(styledText, styledText);
     }
 
     private void refreshHeight() {


### PR DESCRIPTION
Changes:

  org.sterl.llmpeon/src/org/sterl/llmpeon/parts/widget/FileDropSupport.java

  - Added file drag-and-drop support for the chat input.
  - Dropped files are inserted at the cursor as quoted file paths.

  org.sterl.llmpeon/src/org/sterl/llmpeon/parts/widget/TextInputWidget.java

  - Uses FileDropSupport for file drag-and-drop.

  org.sterl.llmpeon.test/src/org/sterl/llmpeon/parts/widget/FileDropSupportTest.java

  - Added tests for file path formatting.
  - Covers multiple files, blank paths, quotes, and OS file drops.
    
   Impact:
  - Only affects drag-and-drop behavior in the prompt input widget.
  - Existing text input, key handling, and auto-resize behavior should remain unchanged.
  - Users can drag files from Eclipse views or the OS into the prompt to insert full file paths. 
 
**Updated the PR description to reflect the FileDropSupport refactoring.**
