### PR TITLE
feat: drag-and-drop

### DIFF
--- a/org.sterl.llmpeon.test/src/org/sterl/llmpeon/parts/widget/FileDropSupportTest.java
+++ b/org.sterl.llmpeon.test/src/org/sterl/llmpeon/parts/widget/FileDropSupportTest.java
@@ -1,0 +1,45 @@
+package org.sterl.llmpeon.parts.widget;
+
+import static org.junit.Assert.assertEquals;
+
+import java.util.List;
+
+import org.eclipse.core.resources.ResourcesPlugin;
+import org.junit.Test;
+
+public class FileDropSupportTest {
+
+    @Test
+    public void formatsSingleDroppedWorkspacePath() {
+        assertEquals("@/llmpeon-parent/pom.xml",
+                FileDropSupport.formatDroppedPaths(List.of("/llmpeon-parent/pom.xml")));
+    }
+
+    @Test
+    public void formatsMultipleDroppedPathsOnSeparateLines() {
+        assertEquals("@/tmp/a.txt\n@/tmp/b.txt",
+                FileDropSupport.formatDroppedPaths(List.of("/tmp/a.txt", "/tmp/b.txt")));
+    }
+
+    @Test
+    public void skipsBlankDroppedPaths() {
+        assertEquals("@/tmp/a.txt",
+                FileDropSupport.formatDroppedPaths(List.of("", "  ", "/tmp/a.txt")));
+    }
+
+    @Test
+    public void readsWorkspaceResourcePaths() {
+        var resource = ResourcesPlugin.getWorkspace().getRoot()
+                .getProject("Project")
+                .getFile("pom.xml");
+
+        assertEquals(List.of("/Project/pom.xml"),
+                FileDropSupport.pathsFromDropData(resource));
+    }
+
+    @Test
+    public void keepsExternalOsFileTransferPaths() {
+        assertEquals(List.of("/tmp/external-file.txt"),
+                FileDropSupport.pathsFromDropData(new String[] { "/tmp/external-file.txt" }));
+    }
+}

--- a/org.sterl.llmpeon/src/org/sterl/llmpeon/parts/AIChatView.java
+++ b/org.sterl.llmpeon/src/org/sterl/llmpeon/parts/AIChatView.java
@@ -9,8 +9,6 @@ import java.util.List;
 import java.util.concurrent.CancellationException;
 import java.util.concurrent.atomic.AtomicReference;
 
-import org.eclipse.core.resources.IFile;
-import org.eclipse.core.resources.IFolder;
 import org.eclipse.core.resources.IProject;
 import org.eclipse.core.resources.IResource;
 import org.eclipse.core.runtime.ILog;
@@ -25,12 +23,9 @@ import org.eclipse.core.runtime.preferences.InstanceScope;
 import org.eclipse.e4.ui.di.Focus;
 import org.eclipse.e4.ui.services.IServiceConstants;
 import org.eclipse.jdt.core.IClassFile;
-import org.eclipse.jdt.core.ICompilationUnit;
-import org.eclipse.jdt.core.IJavaProject;
 import org.eclipse.jface.text.ITextSelection;
 import org.eclipse.jface.viewers.ISelection;
 import org.eclipse.jface.viewers.IStructuredSelection;
-import org.eclipse.jface.viewers.ITreeSelection;
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.layout.GridData;
 import org.eclipse.swt.layout.GridLayout;
@@ -253,37 +248,12 @@ public class AIChatView implements EclipseAiMonitor {
     public void onSelection(@Named(IServiceConstants.ACTIVE_SELECTION) Object o) {
         if (o instanceof ITextSelection) return;
         
-        if (o instanceof ITreeSelection ts) {
-            if (ts.isEmpty()) o = null;
-            else o = ts.getFirstElement();
-        } else if (o instanceof IStructuredSelection ss) {
-            if (ss.isEmpty()) o = null;
-            else o = ss.getFirstElement();
-        }
         userContext.setClassFile(null);
-        final IResource selection;
-        if (o instanceof ICompilationUnit cu) {
-            selection = cu.getResource();
-        } else if (o instanceof IFile f) {
-            selection = f;
-        } else if (o instanceof IResource r) {
-            selection = r;
-        } else if (o instanceof IProject p) {
-            selection = p;
-        } else if (o instanceof IFolder f) {
-            selection = f;
-        } else if (o instanceof IJavaProject jp) {
-            selection = jp.getResource();
-        } else if(o instanceof IClassFile cf) {
-            userContext.setClassFile(cf);
-            selection = cf.getResource();
-        } else if (o instanceof IWorkingSet) {
-            selection = null;
-        } else if (o != null) {
-            LOG.info("Unknown resource type selected " + o.getClass());
-            selection = null;
-        } else {
-            selection = null;
+        var selectionElement = EclipseUtil.selectionElement(o).orElse(null);
+        if (selectionElement instanceof IClassFile classFile) userContext.setClassFile(classFile);
+        var selection = EclipseUtil.resolveResource(selectionElement).orElse(null);
+        if (selection == null && selectionElement != null && !(selectionElement instanceof IWorkingSet)) {
+            LOG.info("Unknown resource type selected " + selectionElement.getClass());
         }
         userContext.setTextSelection(null);
         userContext.setSelectedResource(selection);

--- a/org.sterl.llmpeon/src/org/sterl/llmpeon/parts/shared/EclipseUtil.java
+++ b/org.sterl.llmpeon/src/org/sterl/llmpeon/parts/shared/EclipseUtil.java
@@ -12,12 +12,19 @@ import org.eclipse.core.resources.IProject;
 import org.eclipse.core.resources.IResource;
 import org.eclipse.core.resources.ResourcesPlugin;
 import org.eclipse.core.runtime.CoreException;
+import org.eclipse.core.runtime.IAdaptable;
 import org.eclipse.core.runtime.IPath;
+import org.eclipse.jdt.core.IClassFile;
 import org.eclipse.jdt.core.ICompilationUnit;
+import org.eclipse.jdt.core.IJavaElement;
+import org.eclipse.jdt.core.IJavaProject;
+import org.eclipse.jface.viewers.IStructuredSelection;
+import org.eclipse.jface.viewers.ITreeSelection;
 import org.eclipse.swt.widgets.Composite;
 import org.eclipse.ui.IEditorInput;
 import org.eclipse.ui.IEditorPart;
 import org.eclipse.ui.PlatformUI;
+import org.eclipse.ui.IWorkingSet;
 import org.eclipse.ui.ide.IDE;
 import org.sterl.llmpeon.shared.StringUtil;
 
@@ -86,6 +93,69 @@ public class EclipseUtil {
             if (cu != null && cu.getResource() instanceof IFile f) {
                 return Optional.of(f);
             }
+        }
+        return Optional.empty();
+    }
+
+    /**
+     * Returns the selected element for common structured Eclipse selections.
+     */
+    public static Optional<Object> selectionElement(Object value) {
+        if (value == null) return Optional.empty();
+        if (value instanceof ITreeSelection selection) {
+            if (selection.isEmpty()) return Optional.empty();
+            return Optional.ofNullable(selection.getFirstElement());
+        }
+        if (value instanceof IStructuredSelection selection) {
+            if (selection.isEmpty()) return Optional.empty();
+            return Optional.ofNullable(selection.getFirstElement());
+        }
+        return Optional.of(value);
+    }
+
+    /**
+     * Resolves common Eclipse selection, JDT, and adaptable objects to a workspace resource.
+     */
+    public static Optional<IResource> resolveResource(Object value) {
+        var element = selectionElement(value);
+        if (element.isEmpty()) return Optional.empty();
+        value = element.get();
+
+        if (value instanceof IWorkingSet) return Optional.empty();
+        if (value instanceof IResource resource) return Optional.of(resource);
+        if (value instanceof ICompilationUnit compilationUnit) {
+            return Optional.ofNullable(compilationUnit.getResource());
+        }
+        if (value instanceof IJavaProject javaProject) {
+            return Optional.ofNullable(javaProject.getResource());
+        }
+        if (value instanceof IClassFile classFile) {
+            return Optional.ofNullable(classFile.getResource());
+        }
+        if (value instanceof IJavaElement javaElement) {
+            return Optional.ofNullable(javaElement.getResource());
+        }
+        if (value instanceof IAdaptable adaptable) {
+            var resource = adaptable.getAdapter(IResource.class);
+            if (resource != null) return Optional.of(resource);
+            var javaElement = adaptable.getAdapter(IJavaElement.class);
+            if (javaElement != null) return Optional.ofNullable(javaElement.getResource());
+        }
+        return Optional.empty();
+    }
+
+    /**
+     * Resolves an absolute disk location back to a workspace resource when Eclipse knows it.
+     */
+    public static Optional<IResource> resolveResourceFromLocation(String path) {
+        if (StringUtil.hasNoValue(path)) return Optional.empty();
+        var root = ResourcesPlugin.getWorkspace().getRoot();
+        var uri = Path.of(path).toUri();
+        for (var file : root.findFilesForLocationURI(uri)) {
+            if (file.exists()) return Optional.of(file);
+        }
+        for (IContainer container : root.findContainersForLocationURI(uri)) {
+            if (container.exists()) return Optional.of(container);
         }
         return Optional.empty();
     }

--- a/org.sterl.llmpeon/src/org/sterl/llmpeon/parts/widget/FileDropSupport.java
+++ b/org.sterl.llmpeon/src/org/sterl/llmpeon/parts/widget/FileDropSupport.java
@@ -1,0 +1,137 @@
+package org.sterl.llmpeon.parts.widget;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.eclipse.core.resources.IResource;
+import org.eclipse.jface.util.LocalSelectionTransfer;
+import org.eclipse.jface.viewers.ISelection;
+import org.eclipse.jface.viewers.IStructuredSelection;
+import org.eclipse.swt.custom.StyledText;
+import org.eclipse.swt.dnd.DND;
+import org.eclipse.swt.dnd.DropTarget;
+import org.eclipse.swt.dnd.DropTargetAdapter;
+import org.eclipse.swt.dnd.DropTargetEvent;
+import org.eclipse.swt.dnd.FileTransfer;
+import org.eclipse.swt.dnd.Transfer;
+import org.eclipse.swt.graphics.Point;
+import org.eclipse.swt.widgets.Control;
+import org.eclipse.ui.part.ResourceTransfer;
+import org.sterl.llmpeon.parts.shared.EclipseUtil;
+import org.sterl.llmpeon.parts.shared.JdtUtil;
+
+final class FileDropSupport {
+
+    private FileDropSupport() {
+    }
+
+    static void install(Control dropControl, StyledText targetText) {
+        var dropTarget = new DropTarget(dropControl, DND.DROP_COPY);
+        dropControl.addDisposeListener(e -> {
+            if (!dropTarget.isDisposed()) dropTarget.dispose();
+        });
+        dropTarget.setTransfer(new Transfer[] {
+                ResourceTransfer.getInstance(),
+                LocalSelectionTransfer.getTransfer(),
+                FileTransfer.getInstance()
+        });
+        dropTarget.addDropListener(new DropTargetAdapter() {
+            @Override
+            public void dragEnter(DropTargetEvent event) {
+                acceptCopy(event);
+            }
+
+            @Override
+            public void dragOperationChanged(DropTargetEvent event) {
+                acceptCopy(event);
+            }
+
+            @Override
+            public void dragOver(DropTargetEvent event) {
+                acceptCopy(event);
+            }
+
+            @Override
+            public void dropAccept(DropTargetEvent event) {
+                acceptCopy(event);
+            }
+
+            @Override
+            public void drop(DropTargetEvent event) {
+                var text = formatDroppedPaths(pathsFromDropData(event.data));
+                if (text.isEmpty()) return;
+                insertAtSelection(targetText, text);
+                targetText.setFocus();
+            }
+        });
+    }
+
+    private static void acceptCopy(DropTargetEvent event) {
+        if (event.detail == DND.DROP_DEFAULT || event.detail == DND.DROP_NONE) {
+            event.detail = DND.DROP_COPY;
+        }
+    }
+
+    private static void insertAtSelection(StyledText targetText, String text) {
+        Point selection = targetText.getSelection();
+        targetText.replaceTextRange(selection.x, selection.y - selection.x, text);
+        targetText.setSelection(selection.x + text.length());
+    }
+
+    static String formatDroppedPaths(List<String> paths) {
+        if (paths == null || paths.isEmpty()) return "";
+
+        var result = new StringBuilder();
+        for (String path : paths) {
+            if (path == null || path.isBlank()) continue;
+            if (!result.isEmpty()) result.append('\n');
+            result.append('@').append(path.strip());
+        }
+        return result.toString();
+    }
+
+    static List<String> pathsFromDropData(Object data) {
+        var paths = new ArrayList<String>();
+        addDropPaths(paths, data);
+        if (paths.isEmpty()) {
+            addDropPaths(paths, LocalSelectionTransfer.getTransfer().getSelection());
+        }
+        return paths;
+    }
+
+    private static void addDropPaths(List<String> paths, Object data) {
+        if (data == null) return;
+        if (data instanceof String[] values) {
+            for (String value : values) addOsPath(paths, value);
+        } else if (data instanceof IResource[] resources) {
+            for (IResource resource : resources) addResourcePath(paths, resource);
+        } else if (data instanceof IStructuredSelection selection) {
+            for (Object element : selection) addElementPath(paths, element);
+        } else if (data instanceof ISelection) {
+            return;
+        } else if (data instanceof Object[] values) {
+            for (Object value : values) addElementPath(paths, value);
+        } else {
+            addElementPath(paths, data);
+        }
+    }
+
+    private static void addElementPath(List<String> paths, Object element) {
+        EclipseUtil.resolveResource(element).ifPresent(resource -> addResourcePath(paths, resource));
+    }
+
+    private static void addResourcePath(List<String> paths, IResource resource) {
+        addPath(paths, JdtUtil.pathOf(resource));
+    }
+
+    private static void addOsPath(List<String> paths, String path) {
+        if (path == null || path.isBlank()) return;
+        var workspaceResource = EclipseUtil.resolveResourceFromLocation(path);
+        if (workspaceResource.isPresent()) addResourcePath(paths, workspaceResource.get());
+        else addPath(paths, path);
+    }
+
+    private static void addPath(List<String> paths, String path) {
+        if (path != null && !path.isBlank()) paths.add(path);
+    }
+}

--- a/org.sterl.llmpeon/src/org/sterl/llmpeon/parts/widget/TextInputWidget.java
+++ b/org.sterl.llmpeon/src/org/sterl/llmpeon/parts/widget/TextInputWidget.java
@@ -50,6 +50,8 @@ public class TextInputWidget extends Composite {
         styledText = new StyledText(this, SWT.MULTI | SWT.WRAP);
         styledText.setLayoutData(new GridData(SWT.FILL, SWT.FILL, true, true));
         styledText.addModifyListener(e -> refreshHeight());
+        FileDropSupport.install(this, styledText);
+        FileDropSupport.install(styledText, styledText);
 
         popupMenu = new Menu(parent.getShell(), SWT.POP_UP);
         addUndoRedoSupport(popupMenu);


### PR DESCRIPTION
Based on your review feedback on PR [#70](https://github.com/sterlp/eclipse-peon-ai/pull/70) , I reworked the implementation and pushed a new version.

Changes:
  - Feature
    - When dragging and dropping workspace resources, the workspace-relative path is inserted.
    - When dragging and dropping files from disk, the absolute disk path is inserted.
  - Code
    - Isolated drag-and-drop behavior in FileDropSupport to minimize changes to TextInputWidget.
    - As you suggested, I moved the duplicated logic from AiChatView into EclipseUtil and reused it from the drag-and-drop implementation.