### PR TITLE
Fix chat widget init on Linux/WebKit2

### DIFF
--- a/org.sterl.llmpeon/resources/chat/chat.html
+++ b/org.sterl.llmpeon/resources/chat/chat.html
@@ -381,7 +381,8 @@
         //appendMessage({role: "USER", message: "Write hello world"});
 */
 
-    if (typeof onChatViewReady === 'function') onChatViewReady();
+    // Signal to the Eclipse SWT browser that the page is ready
+    document.title = 'javaReady';
 </script>
 
 </html>

--- a/org.sterl.llmpeon/src/org/sterl/llmpeon/parts/widget/ChatMarkdownWidget.java
+++ b/org.sterl.llmpeon/src/org/sterl/llmpeon/parts/widget/ChatMarkdownWidget.java
@@ -12,7 +12,8 @@ import org.eclipse.core.runtime.FileLocator;
 import org.eclipse.core.runtime.Path;
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.browser.Browser;
-import org.eclipse.swt.browser.BrowserFunction;
+import org.eclipse.swt.browser.TitleEvent;
+import org.eclipse.swt.browser.TitleListener;
 import org.eclipse.swt.layout.FillLayout;
 import org.eclipse.swt.widgets.Composite;
 import org.osgi.framework.FrameworkUtil;
@@ -48,19 +49,23 @@ public class ChatMarkdownWidget extends Composite {
         setLayout(new FillLayout());
 
         browser = new Browser(this, SWT.NONE);
-        new BrowserFunction(browser, "onChatViewReady") {
+
+        // BrowserFunction is not reliably supported by all SWT browser engines (e.g. WebKit2 on Linux/GTK),
+        // so we use title changes from JavaScript (document.title = "javaReady") as a ready signal instead.
+        browser.addTitleListener(new TitleListener() {
             @Override
-            public Object function(Object[] arguments) {
-                EclipseUtil.runInUiThread(parent, () -> {
-                    browserReady = true;
-                    String r;
-                    while ((r = pendingExecutions.poll()) != null) {
-                        browser.execute(r);
-                    }
-                });
-                return null;
+            public void changed(TitleEvent event) {
+                if ("javaReady".equals(event.title)) {
+                    EclipseUtil.runInUiThread(parent, () -> {
+                        browserReady = true;
+                        String r;
+                        while ((r = pendingExecutions.poll()) != null) {
+                            browser.execute(r);
+                        }
+                    });
+                }
             }
-        };
+        });
 
         clear();
     }
@@ -166,7 +171,7 @@ public class ChatMarkdownWidget extends Composite {
     }
     
     /**
-     * Reload the while view - clean everything away ....
+     * Reload the whole view - clean everything away ....
      */
     public void clear() {
         this.browserReady = false;


### PR DESCRIPTION
Since commit 00919b6, the chat window is no longer updated in my Eclipse, which runs on Debian Linux/GTK.

Investigation of this issue shows that registering a JavaScript function via BrowserFunction does not seem to work with the current WebKit version (libwebkit2gtk-4.1-0 2.52.e-2~deb13).

As a workaround I replaced the javaReady BrowserFunction with a title-based ready signal:

- Java side listens for document.title == "javaReady"
- chat.html sets document.title = "javaReady" when the page is ready

This keeps the existing browserReady/safeExecute logic but makes the initialization work on Linux as well as on other platforms.

I could only test this on Linux; feedback from other platforms is welcome.