### PR TITLE
feat: open diff-file in editor on click (#96)

### DIFF
--- a/org.sterl.llmpeon/resources/chat/chat.html
+++ b/org.sterl.llmpeon/resources/chat/chat.html
@@ -171,6 +171,16 @@
             animation: blink-cursor 1s step-end infinite;
             margin-left: 4px;
         }
+
+        .message.diff .d2h-file-name {
+            cursor: pointer;
+            color: #0969da;
+            text-decoration: underline;
+        }
+
+        .message.diff .d2h-file-name:hover {
+            text-decoration: none;
+        }
     </style>
 
     <script src="./highlight.min.js"></script>
@@ -280,6 +290,12 @@
         }
 
         document.addEventListener("click", e => {
+            const name = e.target.closest(".d2h-file-name");
+            if (name) {
+                const path = (name.textContent || "").trim();
+                if (path) window.location.href = "peon-open:" + encodeURIComponent(path);
+                return;
+            }
             const btn = e.target.closest(".copy-btn");
             if (!btn) return;
             const code = btn.closest(".code-pre")?.querySelector(".hljs");

--- a/org.sterl.llmpeon/resources/chat/chat.html
+++ b/org.sterl.llmpeon/resources/chat/chat.html
@@ -293,7 +293,7 @@
             const name = e.target.closest(".d2h-file-name");
             if (name) {
                 const path = (name.textContent || "").trim();
-                if (path) window.location.href = "peon-open:" + encodeURIComponent(path);
+                if (path) window.location.href = "open-in-editor:" + encodeURIComponent(path);
                 return;
             }
             const btn = e.target.closest(".copy-btn");

--- a/org.sterl.llmpeon/src/org/sterl/llmpeon/parts/shared/EclipseUtil.java
+++ b/org.sterl.llmpeon/src/org/sterl/llmpeon/parts/shared/EclipseUtil.java
@@ -66,6 +66,15 @@ public class EclipseUtil {
         }
     }
 
+    /**
+     * Returns {@code true} when the given workspace file is the currently active editor.
+     * Must be called from the UI thread.
+     */
+    public static boolean isOpenInEditor(IFile file) {
+        if (file == null) return false;
+        return getOpenFile().map(file::equals).orElse(false);
+    }
+
     public static IProject firstOpenOrSelectedProject() {
         var openFile = getOpenFile();
         if (openFile.isPresent()) return openFile.get().getProject();

--- a/org.sterl.llmpeon/src/org/sterl/llmpeon/parts/widget/ChatMarkdownWidget.java
+++ b/org.sterl.llmpeon/src/org/sterl/llmpeon/parts/widget/ChatMarkdownWidget.java
@@ -3,15 +3,19 @@ package org.sterl.llmpeon.parts.widget;
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.URL;
+import java.net.URLDecoder;
 import java.nio.charset.StandardCharsets;
 import java.time.Duration;
 import java.time.Instant;
 import java.util.concurrent.atomic.AtomicInteger;
 
+import org.eclipse.core.resources.IFile;
 import org.eclipse.core.runtime.FileLocator;
 import org.eclipse.core.runtime.Path;
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.browser.Browser;
+import org.eclipse.swt.browser.LocationEvent;
+import org.eclipse.swt.browser.LocationListener;
 import org.eclipse.swt.browser.TitleEvent;
 import org.eclipse.swt.browser.TitleListener;
 import org.eclipse.swt.layout.FillLayout;
@@ -64,6 +68,27 @@ public class ChatMarkdownWidget extends Composite {
                         }
                     });
                 }
+            }
+        });
+
+        browser.addLocationListener(new LocationListener() {
+            @Override
+            public void changing(LocationEvent event) {
+                final String prefix = "peon-open:";
+                if (event.location == null || !event.location.startsWith(prefix)) return;
+                event.doit = false;
+                var path = URLDecoder.decode(
+                        event.location.substring(prefix.length()), StandardCharsets.UTF_8);
+                EclipseUtil.resolveInEclipse(path)
+                        .filter(IFile.class::isInstance)
+                        .map(IFile.class::cast)
+                        .filter(f -> !EclipseUtil.isOpenInEditor(f))
+                        .ifPresent(EclipseUtil::openInEditor);
+            }
+
+            @Override
+            public void changed(LocationEvent event) {
+                // no-op
             }
         });
 

--- a/org.sterl.llmpeon/src/org/sterl/llmpeon/parts/widget/ChatMarkdownWidget.java
+++ b/org.sterl.llmpeon/src/org/sterl/llmpeon/parts/widget/ChatMarkdownWidget.java
@@ -74,7 +74,7 @@ public class ChatMarkdownWidget extends Composite {
         browser.addLocationListener(new LocationListener() {
             @Override
             public void changing(LocationEvent event) {
-                final String prefix = "peon-open:";
+                final String prefix = "open-in-editor:";
                 if (event.location == null || !event.location.startsWith(prefix)) return;
                 event.doit = false;
                 var path = URLDecoder.decode(


### PR DESCRIPTION
[#96](https://github.com/sterlp/eclipse-peon-ai/issues/96)
<img width="868" height="451" alt="스크린샷 2026-06-24 13 30 38" src="https://github.com/user-attachments/assets/b9ba9c05-b2ae-4b0d-9463-7d8f7395cf92" />

## [Feature]
- You can open a file in the Eclipse editor by clicking its path in the chat diff view.

## [Implementation]
- chat.html — Link styling for .d2h-file-name; click sends open-in-editor:<path> to Java.
- ChatMarkdownWidget.java — LocationListener intercepts the URL, resolves the path, and calls openInEditor.
- EclipseUtil.java — isOpenInEditor() checks whether the file is the active editor.