### PR TITLE
Add support for displaying AI responses in chat in real time

### DIFF
--- a/org.sterl.llmpeon.core/src/main/java/org/sterl/llmpeon/ai/LlmConfig.java
+++ b/org.sterl.llmpeon.core/src/main/java/org/sterl/llmpeon/ai/LlmConfig.java
@@ -98,6 +98,8 @@ public class LlmConfig {
     @Default
     private final boolean debugMode = false;
     @Default
+    private final boolean showRealtimeAiResponse = false;
+    @Default
     private final Map<String, String> queryParams = new LinkedHashMap<>();
     @Default
     private final Map<String, String> headerParams = new LinkedHashMap<>();

--- a/org.sterl.llmpeon/resources/chat/chat.html
+++ b/org.sterl.llmpeon/resources/chat/chat.html
@@ -251,6 +251,56 @@
             window.scrollTo(0, document.body.scrollHeight);
         }
 
+		function updateLastThinkingMessage(messagePart) {
+		    const container = document.getElementById("chat");
+		    const lastMessage = container.lastElementChild;
+		    const delta = messagePart ?? "";
+		    
+		    if (lastMessage && lastMessage.classList.contains('THINK')) {
+		        const existing = lastMessage.dataset.raw || "";
+		        const updated = existing + delta;
+		        lastMessage.dataset.raw = updated;
+		        const contentDiv = lastMessage.querySelector('.thinking-content');
+		        if (contentDiv) {
+		            contentDiv.innerHTML = md.render(updated);
+		        } else {
+		            lastMessage.innerHTML = '<div class="thinking-content">' + md.render(updated) + '</div>';
+		        }
+		    } else {
+		        const div = document.createElement("div");
+		        div.className = "message THINK";
+		        div.dataset.raw = delta;
+		        div.innerHTML = '<div class="thinking-content">' + md.render(delta) + '</div>';
+		        container.appendChild(div);
+		    }
+		    window.scrollTo(0, document.body.scrollHeight);
+		}
+
+		function updateLastAnsweringMessage(messagePart) {
+		    const container = document.getElementById("chat");
+		    const lastMessage = container.lastElementChild;
+		    const delta = messagePart ?? "";
+		    
+		    if (lastMessage && lastMessage.classList.contains('AI')) {
+		        const existing = lastMessage.dataset.raw || "";
+		        const updated = existing + delta;
+		        lastMessage.dataset.raw = updated;
+		        const contentDiv = lastMessage.querySelector('.message-content');
+		        if (contentDiv) {
+		            contentDiv.innerHTML = md.render(updated);
+		        } else {
+		            lastMessage.innerHTML = '<div class="message-content">' + md.render(updated) + '</div>';
+		        }
+		    } else {
+		        const div = document.createElement("div");
+		        div.className = "message AI";
+		        div.dataset.raw = delta;
+		        div.innerHTML = '<div class="message-content">' + md.render(delta) + '</div>';
+		        container.appendChild(div);
+		    }
+		    window.scrollTo(0, document.body.scrollHeight);
+		}
+
         function updateLiveResponse(stateMessage, tokPerSec, thinkChunk) {
             var el = document.getElementById("live-status");
             if (!el) {
@@ -276,6 +326,8 @@
         function appendMessage(message) {
             hideLiveStatus();
             if (message.role === 'TOOL') {toolMessage(message.message); return;}
+            if (message.role === 'THINK') {updateLastThinkingMessage(message.message); return;}
+            if (message.role === 'ANSWER') {updateLastAnsweringMessage(message.message); return;}
             const container = document.getElementById("chat");
             const lastMessage = container.lastElementChild;
             if (lastMessage && lastMessage.classList.contains(message.role)) {
@@ -288,7 +340,7 @@
             }
             window.scrollTo(0, document.body.scrollHeight);
         }
-
+        
         document.addEventListener("click", e => {
             const name = e.target.closest(".d2h-file-name");
             if (name) {

--- a/org.sterl.llmpeon/src/org/sterl/llmpeon/parts/AIChatView.java
+++ b/org.sterl.llmpeon/src/org/sterl/llmpeon/parts/AIChatView.java
@@ -319,7 +319,11 @@ public class AIChatView implements EclipseAiMonitor {
             } else {
                 chatHistory.hideLiveStatus();
             }
-            chatHistory.appendMessage(m);
+
+            // show message, but suppress live updated message when it is already shown
+            if ((m.role() != SimpleMessage.Type.THINK && m.role() != SimpleMessage.Type.AI) || !chatHistory.isShowRealtimeAiResponse()) {
+                chatHistory.appendMessage(m);
+            }
             actionsBar.updateCompact(ai.getMemory().getTotalTokenUsed(), aiService.getConfig().getAutoCompactAfter());
         });
     }
@@ -411,6 +415,7 @@ public class AIChatView implements EclipseAiMonitor {
         if (lastAppliedConfig != null && lastAppliedConfig.equals(config)) return;
         lastAppliedConfig = config;
         aiService.updateConfig(config);
+        chatHistory.setShowRealtimeAiResponse(config.isShowRealtimeAiResponse());
 
         actionsBar.setAgents(aiService.getAgents());
         actionsBar.updateModeUI(aiService.getActiveAgent());

--- a/org.sterl.llmpeon/src/org/sterl/llmpeon/parts/PeonConstants.java
+++ b/org.sterl.llmpeon/src/org/sterl/llmpeon/parts/PeonConstants.java
@@ -26,6 +26,7 @@ public interface PeonConstants {
     String PREF_SHELL_CONFIRMATION_ENABLED = "llm.shellConfirmationEnabled";
     
     String PREF_LOG_RESPONSE       = "llm.logResponse";
+    String PREF_SHOW_REALTIME_AI_RESPONSE = "llm.showRealtimeAiResponse";
     String PREF_PLAN_TEMPERATURE   = "llm.planTemperature";
     String PREF_DEV_TEMPERATURE    = "llm.devTemperature";
     String PREF_QUERY_PARAMS       = "llm.queryParams";

--- a/org.sterl.llmpeon/src/org/sterl/llmpeon/parts/config/AiAdvancedPreferenceView.java
+++ b/org.sterl.llmpeon/src/org/sterl/llmpeon/parts/config/AiAdvancedPreferenceView.java
@@ -67,6 +67,7 @@ public class AiAdvancedPreferenceView extends FieldEditorPreferencePage implemen
         addField(headerParamEditor);
         
         addField(new BooleanFieldEditor(PeonConstants.PREF_LOG_RESPONSE,          "Debug mode (logs requests & responses)", getFieldEditorParent()));
+        addField(new BooleanFieldEditor(PeonConstants.PREF_SHOW_REALTIME_AI_RESPONSE, "Show real-time AI response in chat", getFieldEditorParent()));
     }
 
     /**

--- a/org.sterl.llmpeon/src/org/sterl/llmpeon/parts/config/LlmPreferenceInitializer.java
+++ b/org.sterl.llmpeon/src/org/sterl/llmpeon/parts/config/LlmPreferenceInitializer.java
@@ -98,6 +98,7 @@ public class LlmPreferenceInitializer extends AbstractPreferenceInitializer {
             .planTemperature(parseDoublePref(prefs, PeonConstants.PREF_PLAN_TEMPERATURE, DEFAULT.getPlanTemperature()))
             .devTemperature(parseDoublePref(prefs, PeonConstants.PREF_DEV_TEMPERATURE, DEFAULT.getDevTemperature()))
             .debugMode(prefs.getBoolean(PeonConstants.PREF_LOG_RESPONSE, false))
+            .showRealtimeAiResponse(prefs.getBoolean(PeonConstants.PREF_SHOW_REALTIME_AI_RESPONSE, false))
             .queryParams(parseCsvMap(prefs.get(PeonConstants.PREF_QUERY_PARAMS, "")))
             .headerParams(parseCsvMap(prefs.get(PeonConstants.PREF_HEADER_PARAMS, "")))
             .shellCommandConfirmationRequired("always".equals(prefs.get(PeonConstants.PREF_SHELL_CONFIRMATION_ENABLED, "")) ||

--- a/org.sterl.llmpeon/src/org/sterl/llmpeon/parts/widget/ChatMarkdownWidget.java
+++ b/org.sterl.llmpeon/src/org/sterl/llmpeon/parts/widget/ChatMarkdownWidget.java
@@ -42,6 +42,7 @@ public class ChatMarkdownWidget extends Composite {
     
     private final AtomicInteger streamingTokenCount = new AtomicInteger(0);
     private final Composite parent;
+    private boolean showRealtimeAiResponse = false;
     
     private volatile boolean browserReady = false;
     private final java.util.Queue<String> pendingExecutions = 
@@ -135,6 +136,14 @@ public class ChatMarkdownWidget extends Composite {
         }
     }
 
+    public void setShowRealtimeAiResponse(boolean show) {
+        this.showRealtimeAiResponse = show;
+    }
+
+    public boolean isShowRealtimeAiResponse() {
+        return showRealtimeAiResponse;
+    }
+
     public void appendMessage(SimpleMessage msg) {
         try {
             safeExecute("appendMessage(" + mapper.writeValueAsString(msg) + ");");
@@ -159,7 +168,34 @@ public class ChatMarkdownWidget extends Composite {
             EclipseUtil.runInUiThread(parent, this::hideLiveStatus);
         } else {
             updateRunningChunk(r, tokens);
+            if (showRealtimeAiResponse) {
+                if (r.type() == Type.THINK) {
+                    updateThinkingMessageInUIThread(r.value());
+                } else if (r.type() == Type.ANSWER) {
+                    updateAnsweringMessageInUIThread(r.value());
+                }
+            }
         }
+    }
+
+    private void updateThinkingMessageInUIThread(String text) {
+        EclipseUtil.runInUiThread(parent, () -> {
+            try {
+                browser.execute("updateLastThinkingMessage(" + mapper.writeValueAsString(text) + ");");
+            } catch (Exception e) {
+                // ignore
+            }
+        });
+    }
+
+    private void updateAnsweringMessageInUIThread(String text) {
+        EclipseUtil.runInUiThread(parent, () -> {
+            try {
+                browser.execute("updateLastAnsweringMessage(" + mapper.writeValueAsString(text) + ");");
+            } catch (Exception e) {
+                // ignore
+            }
+        });
     }
 
     private void updateRunningChunk(OnPartialAiResponse r, int tokens) {
@@ -173,16 +209,20 @@ public class ChatMarkdownWidget extends Composite {
         };
         if (r.type() == Type.START) {
             updateLiveResponseInUIThread(state, 0, "");
-        } else if (tokens > 0 && tokens % 20 == 0) {
-            double tokPerSec = tokens / (double) elapsed;
+        } else if (tokens == 1 || (tokens > 0 && tokens % 20 == 0)) {
+            double tokPerSec = elapsed > 0 ? tokens / (double) elapsed : 0;
             updateLiveResponseInUIThread(state, tokPerSec, tokens + " tokens generated");
         }
     }
     
     public void updateLiveResponseInUIThread(String state, double tokPerSec, String safeChunk) {
-        EclipseUtil.runInUiThread(parent, () -> browser.execute(
-            "updateLiveResponse('" + state + "', " + tokPerSec + ", '" + safeChunk + "');"
-        ));
+        EclipseUtil.runInUiThread(parent, () -> {
+            try {
+                browser.execute("updateLiveResponse(" + mapper.writeValueAsString(state) + ", " + tokPerSec + ", " + mapper.writeValueAsString(safeChunk) + ");");
+            } catch (JsonProcessingException e) {
+                // ignore
+            }
+        });
     }
 
     public void showDiff(String unifiedDiff) {
@@ -195,9 +235,6 @@ public class ChatMarkdownWidget extends Composite {
         }
     }
     
-    /**
-     * Reload the whole view - clean everything away ....
-     */
     public void clear() {
         this.browserReady = false;
         this.pendingExecutions.clear();


### PR DESCRIPTION
When interacting with a slow AI in question-and-answer mode, it can be helpful to see the response as it is generated while waiting for the complete result. This provides users with immediate feedback and gives them something to follow during longer processing times.

This commit introduces a preference for displaying AI responses in real time, token by token. By default, responses are displayed only after generation is complete.