### PR TITLE
Update chat colors on theme change

### DIFF
--- a/org.sterl.llmpeon/resources/chat/chat.html
+++ b/org.sterl.llmpeon/resources/chat/chat.html
@@ -454,16 +454,25 @@
 
         function setTheme(theme) {
             document.body.setAttribute('data-peon-theme', theme);
-            window._peonDiffColorScheme = theme;
             // Load the appropriate syntax highlighting CSS based on theme
             const cssFile = theme === 'dark' ? './atom-one-dark.min.css' : './atom-one-light.min.css';
             const link = document.getElementById('atom-syntax-css');
             if (link) {
                 link.href = cssFile;
             }
+            updateThemeOnExistingDiffs(theme);
         }
 
-        function appendDiff(diffString, colorScheme) {
+        function updateThemeOnExistingDiffs(theme) {
+            const isDark = theme === 'dark';
+            Array.from(document.getElementsByClassName("d2h-wrapper")).forEach(el => {
+                const oldClass = isDark ? "d2h-light-color-scheme" : "d2h-dark-color-scheme";
+                const newClass = isDark ? "d2h-dark-color-scheme" : "d2h-light-color-scheme";
+                el.classList.replace(oldClass, newClass);
+            });
+        }
+
+        function appendDiff(diffString) {
             hideLiveStatus();
             const container = document.getElementById("chat");
             const div = document.createElement("div");
@@ -475,7 +484,7 @@
                 outputFormat: 'line-by-line',
                 highlight: true,
                 matching: 'lines',
-                colorScheme: colorScheme || window._peonDiffColorScheme || 'light'
+                colorScheme: document.body.getAttribute('data-peon-theme') || 'light'
             });
             diff2htmlUi.draw();
             window.scrollTo(0, document.body.scrollHeight);
@@ -501,7 +510,7 @@
                         hideLiveStatus();
                         break;
                     case "appendDiff":
-                        appendDiff(event.data.diff, event.data.colorScheme);
+                        appendDiff(event.data.diff);
                         break;
                     case "clearMessages":
                         clearMessages();

--- a/org.sterl.llmpeon/resources/chat/test-chat.html
+++ b/org.sterl.llmpeon/resources/chat/test-chat.html
@@ -172,7 +172,7 @@
             diff += '+            .filter(u -> !u.startsWith("deleted:"))\n';
             diff += '+            .collect(Collectors.toList());\n';
             diff += '     }\n';
-            send({type: 'appendDiff', diff: diff, colorScheme: 'light'});
+            send({type: 'appendDiff', diff: diff});
         }
 
         function testSetTheme(theme) {

--- a/org.sterl.llmpeon/src/org/sterl/llmpeon/parts/AIChatView.java
+++ b/org.sterl.llmpeon/src/org/sterl/llmpeon/parts/AIChatView.java
@@ -18,7 +18,6 @@ import org.eclipse.core.runtime.Status;
 import org.eclipse.core.runtime.jobs.Job;
 import org.eclipse.core.runtime.preferences.IEclipsePreferences.IPreferenceChangeListener;
 import org.eclipse.core.runtime.preferences.InstanceScope;
-import org.eclipse.e4.core.contexts.IEclipseContext;
 import org.eclipse.e4.ui.di.Focus;
 import org.eclipse.e4.ui.services.IServiceConstants;
 import org.eclipse.jdt.core.IClassFile;
@@ -78,8 +77,6 @@ public class AIChatView implements EclipseAiMonitor {
 
     private static final ILog LOG = Platform.getLog(AIChatView.class);
 
-    @Inject IEclipseContext context;
-
     // Declared first so the aiService field initializer lambdas can capture them
     // without violating the Java forward-reference restriction.
     // All are null until @PostConstruct runs; the lambdas are only ever invoked after that.
@@ -132,12 +129,11 @@ public class AIChatView implements EclipseAiMonitor {
         headerBar = new HeaderBarWidget(parent, SWT.NONE,
                 () -> aiService.getActiveAgent().getName(),
                 aiService::getToolStatus,
-                aiService::getStatusAgents,
-                context);
+                aiService::getStatusAgents);
         headerBar.setLayoutData(new GridData(SWT.FILL, SWT.CENTER, true, false));
 
         // Borderless — a border's top edge would read as a divider against the flush header.
-        chatHistory = new ChatMarkdownWidget(parent, SWT.NONE, context);
+        chatHistory = new ChatMarkdownWidget(parent, SWT.NONE);
         chatHistory.setLayoutData(new GridData(SWT.FILL, SWT.FILL, true, true));
 
         // inputBlock carries the single outer border for the entire input area (sections 2+3+4).

--- a/org.sterl.llmpeon/src/org/sterl/llmpeon/parts/shared/EclipseUiUtil.java
+++ b/org.sterl.llmpeon/src/org/sterl/llmpeon/parts/shared/EclipseUiUtil.java
@@ -2,13 +2,20 @@ package org.sterl.llmpeon.parts.shared;
 
 import org.eclipse.e4.core.contexts.IEclipseContext;
 import org.eclipse.e4.ui.css.swt.theme.IThemeEngine;
+import org.eclipse.jface.util.IPropertyChangeListener;
+import org.eclipse.jface.util.PropertyChangeEvent;
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.layout.RowData;
 import org.eclipse.swt.widgets.Composite;
 import org.eclipse.swt.widgets.Label;
 import org.eclipse.ui.PlatformUI;
+import org.eclipse.ui.themes.IThemeManager;
 
 public class EclipseUiUtil {
+
+    public interface ThemeChangeListener {
+        void onThemeChange(String theme);
+    }
 
     public static final String DARK_THEME_ID = "org.eclipse.e4.ui.css.theme.e4_dark";
     public static final String DARK_THEME_NAME = "dark";
@@ -16,6 +23,7 @@ public class EclipseUiUtil {
     public static final String CSS_CLASS_HEADER_BAR_WIDGET = "org-sterl-llmpeon-parts-widget-header-bar-widget";
     public static final String CSS_CLASS_USER_QUESTION_RESPONSE_WIDGET = "org-sterl-llmpeon-parts-widget-user-question-response-widget";
     public static final String CSS_CLASS_TEXT_INPUT_WIDGET = "org-sterl-llmpeon-parts-widget-text-input-widget";
+    private static final String DARK_FOREGROUND_PROPERTY_NAME = "org.eclipse.ui.workbench.DARK_FOREGROUND";
 
     public static Label newSeparator(Composite parent) {
         var result = new Label(parent, SWT.SEPARATOR | SWT.VERTICAL);
@@ -26,13 +34,40 @@ public class EclipseUiUtil {
     /**
      * Resolves the current Eclipse theme as {@code "dark"} or {@code "light"}.
      */
-    public static String resolveTheme(IEclipseContext context) {
-        if (PlatformUI.isWorkbenchRunning() && context != null) {
+    public static String resolveTheme() {
+        return PlatformUI.isWorkbenchRunning()
+                ? resolveTheme(PlatformUI.getWorkbench().getService(IEclipseContext.class))
+                : LIGHT_THEME_NAME;
+    }
+
+    private static String resolveTheme(IEclipseContext context) {
+        if (context != null) {
             IThemeEngine themeEngine = context.get(IThemeEngine.class);
             if (themeEngine != null && DARK_THEME_ID.equals(themeEngine.getActiveTheme().getId())) {
                 return DARK_THEME_NAME;
             }
         }
         return LIGHT_THEME_NAME;
+    }
+
+
+    public static void addThemeChangeListener(ThemeChangeListener listener) {
+        IEclipseContext context = PlatformUI.getWorkbench().getService(IEclipseContext.class);
+        var theme = resolveTheme(context);
+        PlatformUI.getWorkbench().getThemeManager().addPropertyChangeListener(new IPropertyChangeListener() {
+            String currentTheme = theme;
+
+            @Override
+            public void propertyChange(PropertyChangeEvent e) {
+                if (e.getProperty().equals(DARK_FOREGROUND_PROPERTY_NAME)
+                        || e.getProperty().equals(IThemeManager.CHANGE_CURRENT_THEME)) {
+                    String newTheme = resolveTheme(context);
+                    if (!currentTheme.equals(newTheme)) {
+                        currentTheme = newTheme;
+                        listener.onThemeChange(newTheme);
+                    }
+                }
+            }
+        });
     }
 }

--- a/org.sterl.llmpeon/src/org/sterl/llmpeon/parts/widget/ChatMarkdownWidget.java
+++ b/org.sterl.llmpeon/src/org/sterl/llmpeon/parts/widget/ChatMarkdownWidget.java
@@ -14,7 +14,6 @@ import java.util.concurrent.atomic.AtomicInteger;
 import org.eclipse.core.resources.IFile;
 import org.eclipse.core.runtime.FileLocator;
 import org.eclipse.core.runtime.Path;
-import org.eclipse.e4.core.contexts.IEclipseContext;
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.browser.Browser;
 import org.eclipse.swt.browser.LocationEvent;
@@ -49,16 +48,14 @@ public class ChatMarkdownWidget extends Composite {
     private boolean showRealtimeAiResponse = false;
     private final StringBuilder thinkText = new StringBuilder();
     private final StringBuilder answerText = new StringBuilder();
-    private final IEclipseContext context;
 
     private volatile boolean browserReady = false;
     private final java.util.Queue<String> pendingMessages = new java.util.concurrent.ConcurrentLinkedQueue<>();
     private volatile String currentTheme = "light";
 
-    public ChatMarkdownWidget(Composite parent, int style, IEclipseContext context) {
+    public ChatMarkdownWidget(Composite parent, int style) {
         super(parent, style);
         this.parent = parent;
-        this.context = context;
         setLayout(new FillLayout());
 
         browser = new Browser(this, SWT.NONE);
@@ -122,6 +119,15 @@ public class ChatMarkdownWidget extends Composite {
             public void changed(LocationEvent event) {
                 // no-op
             }
+        });
+
+        EclipseUiUtil.addThemeChangeListener(theme -> {
+            currentTheme = theme;
+
+            var payload = new LinkedHashMap<String, Object>();
+            payload.put("type", "setTheme");
+            payload.put("theme", theme);
+            postMessage(payload);
         });
 
         clear();
@@ -261,7 +267,6 @@ public class ChatMarkdownWidget extends Composite {
         var payload = new LinkedHashMap<String, Object>();
         payload.put("type", "appendDiff");
         payload.put("diff", unifiedDiff);
-        payload.put("colorScheme", currentTheme);
         postMessage(payload);
     }
 
@@ -269,7 +274,7 @@ public class ChatMarkdownWidget extends Composite {
         this.browserReady = false;
         this.pendingMessages.clear();
         browser.setText(loadChatHtml());
-        currentTheme = EclipseUiUtil.resolveTheme(context);
+        currentTheme = EclipseUiUtil.resolveTheme();
         var payload = new LinkedHashMap<String, Object>();
         payload.put("type", "setTheme");
         payload.put("theme", currentTheme);

--- a/org.sterl.llmpeon/src/org/sterl/llmpeon/parts/widget/HeaderBarWidget.java
+++ b/org.sterl.llmpeon/src/org/sterl/llmpeon/parts/widget/HeaderBarWidget.java
@@ -3,7 +3,6 @@ package org.sterl.llmpeon.parts.widget;
 import java.util.List;
 import java.util.function.Supplier;
 
-import org.eclipse.e4.core.contexts.IEclipseContext;
 import org.eclipse.e4.ui.css.swt.CSSSWTConstants;
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.layout.GridData;
@@ -43,8 +42,7 @@ public class HeaderBarWidget extends Composite {
     public HeaderBarWidget(Composite parent, int style,
             Supplier<String> activeAgentName,
             Supplier<List<ToolStatus>> toolStatus,
-            Supplier<List<NamedAgent>> statusAgents,
-            IEclipseContext context) {
+            Supplier<List<NamedAgent>> statusAgents) {
         super(parent, style);
         this.activeAgentName = activeAgentName;
         this.toolStatus = toolStatus;
@@ -73,7 +71,7 @@ public class HeaderBarWidget extends Composite {
 
         Button hammer = SwtUtil.createIconButton(this,
                 ImageUtil.loadImage(this,
-                        EclipseUiUtil.DARK_THEME_NAME.equals(EclipseUiUtil.resolveTheme(context)) ? ImageUtil.HAMMER_DARK
+                        EclipseUiUtil.DARK_THEME_NAME.equals(EclipseUiUtil.resolveTheme()) ? ImageUtil.HAMMER_DARK
                                 : ImageUtil.HAMMER),
                 "Show which tools are active for the selected agent");
         hammer.setLayoutData(new GridData(SWT.END, SWT.CENTER, false, false));


### PR DESCRIPTION
The chat view (`chat.html`) now gets updated when the Eclipse theme changes. For detecting the theme change an IPropertChangeListener checks for a base ui element color change, then gets the current selected theme from IThemeEngine and notifies its dependent listener if the theme has actually changed.